### PR TITLE
docs: add platform architecture overview

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+- [ ] Changelog entry added (with Change Type, Why, What, Impact, Testing, Docs, Rollback)
+- [ ] README and docs updated (or confirmed N/A)
+- [ ] Tests added/updated and passing locally
+- [ ] Backward compatibility considered (noted breaking changes)
+- [ ] Security and secrets unaffected (or documented mitigation)

--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,0 +1,9 @@
+## [2025-10-04 10:18] Document platform architecture
+**Change Type:** Standard Change  
+**Why:** Provide a shared understanding of the Docker Control Center platform scope and workflows.  
+**What changed:** Added a structured README, architecture overview, and configuration reference for the DCC project.  
+**Impact:** Documentation only; no runtime impact.  
+**Testing:** Not applicable (docs update).  
+**Docs:** README and new docs updated.  
+**Rollback Plan:** Delete the newly added documentation files.  
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# DockerControllCenter
+# Docker Control Center (DCC)
+
+A lightweight control plane for hosting GPU-accelerated AI applications on demand.
+
+## Features
+- Register new AI services through a guided web form with validation.
+- Provision standardized NVIDIA-enabled Docker Compose stacks per application.
+- Mount isolated `/opt/dockerstore/<app>` workspaces into containers at `/app`.
+- Surface live container status and launch URLs on a responsive dashboard without manual refresh cycles.
+
+## Quick Start
+```bash
+# Clone the repository and review the documentation
+git clone https://github.com/example/DockerControllCenter.git
+cd DockerControllCenter
+
+# Ensure Docker, Docker Compose, and the NVIDIA Container Toolkit are installed.
+# Implementation details are tracked in docs/; runtime scripts are pending.
+```
+
+## Configuration
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DCC_STORAGE_ROOT` | `/opt/dockerstore` | Root directory for application checkouts mounted into containers. |
+| `DCC_BASE_IMAGE` | `nvcr.io/nvidia/pytorch:latest` | GPU-enabled base image used in generated Docker Compose files. |
+| `DCC_DASHBOARD_PORT` | `8080` | HTTP port for serving the control center dashboard. |
+| `DCC_REFRESH_INTERVAL` | `auto` | Frontend polling/streaming strategy; must avoid full page refresh loops. |
+
+> Document additional environment variables in `/docs/configuration.md` as they are introduced.
+
+## Usage
+1. Open the dashboard and choose **Add Application**.
+2. Provide the application name, Git repository URL, optional requirements file name, container start command, and service port.
+3. Submit the form to trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
+4. Monitor build progress and container readiness directly in the dashboard. The service URL is listed once the stack is healthy.
+
+Detailed lifecycle and automation guidance lives in [`docs/architecture-overview.md`](docs/architecture-overview.md).
+
+## Development
+- Align UI work with the responsive dashboard requirements outlined in the architecture overview.
+- Add integration tests around compose generation and container health checks once implementation lands.
+- Keep documentation updated alongside feature work.
+
+## Changelog
+See [`Changelog/Changelog.md`](Changelog/Changelog.md).
+
+## License
+TBD.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,58 @@
+# Docker Control Center Architecture Overview
+
+## System Goals
+- Provide a self-service platform for deploying GPU-enabled AI applications such as Stable Diffusion.
+- Standardize runtime environments using a curated NVIDIA Tensor container image.
+- Keep the operator dashboard responsive via push or light polling without full page reloads.
+- Maintain reproducible application workspaces under `/opt/dockerstore/<appname>` for traceability.
+
+## High-Level Workflow
+1. **Application Registration**
+   - User submits the onboarding form containing:
+     - `name`: unique identifier for the application.
+     - `repository`: Git URL to clone.
+     - `requirements_file`: optional override of the Python dependencies file name.
+     - `start_command`: shell command executed inside the container at boot.
+     - `port`: HTTP port exposed by the application.
+   - Validation ensures name uniqueness and mandatory fields.
+
+2. **Workspace Provisioning**
+   - Clone the Git repository into `/opt/dockerstore/<name>`.
+   - Persist metadata (e.g., commit SHA, port, health status) for dashboard queries.
+   - Generate a Docker Compose file referencing the default NVIDIA base image and mapping `/opt/dockerstore/<name>` to `/app`.
+
+3. **Container Orchestration**
+   - Run `docker compose up -d` for the generated stack.
+   - Monitor container logs, GPU resource allocation, and health checks.
+   - Expose the configured port on the host, optionally with HTTPS termination upstream.
+
+4. **Dashboard Visibility**
+   - Reflect container status changes through websockets or server-sent events to avoid full refreshes.
+   - Provide quick links to the hosted application and troubleshooting logs.
+   - Support basic lifecycle actions: restart, stop, remove.
+
+## Component Responsibilities
+| Component | Responsibility |
+| --- | --- |
+| Web Frontend | Responsive UI for onboarding, status, and lifecycle actions. Employs real-time updates without constant refreshes. |
+| API / Backend | Validates submissions, manages Git interactions, renders Compose templates, and tracks container lifecycle. |
+| Worker / Runner | Executes repository cloning, dependency installation, and compose orchestration with GPU support. |
+| Storage Layer | Hosts `/opt/dockerstore` directories and durable metadata (database or flat files). |
+
+## Security Considerations
+- Sanitize user-provided repository URLs and commands to prevent injection.
+- Run cloned code with least privilege; leverage dedicated service accounts.
+- Restrict filesystem mounts to the application directory to avoid host escape.
+- Maintain audit logs for create/update/delete actions.
+
+## Operational Notes
+- Use NVIDIA Container Toolkit on host machines to expose GPU resources inside containers.
+- Track resource usage (GPU, CPU, memory) per application for capacity planning.
+- Implement cleanup routines for orphaned workspaces and stale Compose stacks.
+- Provide backups for `/opt/dockerstore` and metadata to support disaster recovery.
+
+## Future Enhancements
+- Template override support for applications requiring custom images.
+- Integration with authentication providers to limit dashboard access.
+- Automated dependency scanning and vulnerability alerts.
+- API endpoints for CI/CD-driven onboarding.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,38 @@
+# Configuration Reference
+
+The Docker Control Center (DCC) relies on environment variables to orchestrate GPU-ready application containers. Configure these values through your deployment platform (e.g., systemd unit, Docker Compose, Kubernetes secrets).
+
+| Variable | Purpose | Notes |
+| --- | --- | --- |
+| `DCC_STORAGE_ROOT` | Directory hosting application workspaces (`/opt/dockerstore` by default). | Must be writable by the DCC runtime and large enough to store cloned repositories and generated artifacts. |
+| `DCC_BASE_IMAGE` | NVIDIA-enabled Docker image tag for generated services. | Use images compatible with the NVIDIA Container Toolkit and target CUDA version. |
+| `DCC_DASHBOARD_PORT` | Exposed HTTP port for the operator dashboard. | Configure reverse proxy if public access is required. |
+| `DCC_REFRESH_INTERVAL` | Controls UI update cadence (e.g., websocket, SSE, polling). | Favor streaming mechanisms to avoid full page reloads. |
+| `DCC_ALLOWED_REPOS` | Optional allowlist of Git hosts or orgs. | Enforce compliance and security policies. |
+| `DCC_LOG_LEVEL` | Logging verbosity (`info`, `debug`, etc.). | Increase temporarily for troubleshooting. |
+
+## File System Layout
+```
+/opt/dockerstore/
+  <app-name>/
+    requirements.txt (or custom name)
+    docker-compose.yml (generated)
+    metadata.json
+```
+
+## Networking
+- Expose each application port via the generated Compose file.
+- Map host ports to avoid collisions; consider dynamic allocation when scaling.
+- Secure external access with TLS termination (Traefik, Nginx, etc.).
+
+## GPU Access
+- Install the NVIDIA Container Toolkit on the host.
+- Validate GPU visibility with `docker run --rm --gpus all nvidia/cuda:11.8.0-base nvidia-smi` before onboarding workloads.
+
+## Secrets Management
+- Store credentials (e.g., private Git deploy keys) in a secret manager.
+- Mount secrets into the worker runtime rather than checking them into repositories.
+
+## Observability
+- Forward container logs to centralized logging (ELK, Loki).
+- Emit metrics for container lifecycle events, GPU usage, and onboarding errors.


### PR DESCRIPTION
## Why
- Capture the expected onboarding workflow and runtime boundaries for Docker Control Center.
- Provide a reference README for contributors and operators.

## What
- Rewrite the README with features, configuration summary, and usage walkthrough.
- Add detailed architecture and configuration documentation under `docs/`.
- Introduce the standard changelog entry format and PR checklist.

## Impact
- Documentation only; no runtime behavior changes.

## Testing
- Not applicable (docs only change).

## Docs
- README updated
- Added docs/architecture-overview.md
- Added docs/configuration.md

## Changelog Entry
## [2025-10-04 10:18] Document platform architecture
**Change Type:** Standard Change  
**Why:** Provide a shared understanding of the Docker Control Center platform scope and workflows.  
**What changed:** Added a structured README, architecture overview, and configuration reference for the DCC project.  
**Impact:** Documentation only; no runtime impact.  
**Testing:** Not applicable (docs update).  
**Docs:** README and new docs updated.  
**Rollback Plan:** Delete the newly added documentation files.  
**Refs:** N/A


------
https://chatgpt.com/codex/tasks/task_e_68e0f42a23d883339134fe570b64fae3