### PR TITLE
setup: add Node-based installer with rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.npm/
+.DS_Store
+npm-debug.log*

--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -7,3 +7,13 @@
 **Docs:** README and new docs updated.  
 **Rollback Plan:** Delete the newly added documentation files.  
 **Refs:** N/A
+
+## [2025-10-04 11:45] Add automated setup pipeline
+**Change Type:** Normal Change  
+**Why:** Provide a reproducible Node.js-driven installer with rollback for the Docker Control Center environment.  
+**What changed:** Added setup and build scripts, initialized the Node project scaffold, delivered a deluxe placeholder UI, and refreshed README plus setup documentation.  
+**Impact:** Installer may install/remove Docker packages and deploy files under `/opt/dcc`; existing installs are snapshot before changes.  
+**Testing:** `npm run build`  
+**Docs:** README, docs/setup.md, docs/configuration.md updated.  
+**Rollback Plan:** Run `node scripts/setup.js --rollback` or revert this commit.  
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -7,16 +7,26 @@ A lightweight control plane for hosting GPU-accelerated AI applications on deman
 - Provision standardized NVIDIA-enabled Docker Compose stacks per application.
 - Mount isolated `/opt/dockerstore/<app>` workspaces into containers at `/app`.
 - Surface live container status and launch URLs on a responsive dashboard without manual refresh cycles.
+- Bootstrap environments with a Node.js installer that verifies Docker, builds the UX placeholder, and deploys artifacts to `/opt/dcc`.
 
 ## Quick Start
 ```bash
-# Clone the repository and review the documentation
+# Clone the repository and move into it
 git clone https://github.com/example/DockerControllCenter.git
 cd DockerControllCenter
 
-# Ensure Docker, Docker Compose, and the NVIDIA Container Toolkit are installed.
-# Implementation details are tracked in docs/; runtime scripts are pending.
+# Run the installer (Node.js 18+ required)
+node scripts/setup.js --install
 ```
+
+Need to undo the setup? Execute `node scripts/setup.js --rollback` to restore the previous state.
+
+## Setup Automation
+The installer orchestrates prerequisite checks, Docker package installation (via `apt-get` when
+missing), build execution, and artifact deployment. It records its actions to support a full
+rollback flow that removes files and Docker packages it introduced. Configure the destination with
+`DCC_INSTALL_DIR` or accept the default `/opt/dcc`. Detailed guidance lives in
+[`docs/setup.md`](docs/setup.md).
 
 ## Configuration
 | Variable | Default | Description |
@@ -25,6 +35,7 @@ cd DockerControllCenter
 | `DCC_BASE_IMAGE` | `nvcr.io/nvidia/pytorch:latest` | GPU-enabled base image used in generated Docker Compose files. |
 | `DCC_DASHBOARD_PORT` | `8080` | HTTP port for serving the control center dashboard. |
 | `DCC_REFRESH_INTERVAL` | `auto` | Frontend polling/streaming strategy; must avoid full page refresh loops. |
+| `DCC_INSTALL_DIR` | `/opt/dcc` | Target directory used by the setup automation for deploying build artifacts. |
 
 > Document additional environment variables in `/docs/configuration.md` as they are introduced.
 
@@ -37,6 +48,7 @@ cd DockerControllCenter
 Detailed lifecycle and automation guidance lives in [`docs/architecture-overview.md`](docs/architecture-overview.md).
 
 ## Development
+- Run `npm run build` to regenerate the deluxe placeholder UI assets in `dist/`.
 - Align UI work with the responsive dashboard requirements outlined in the architecture overview.
 - Add integration tests around compose generation and container health checks once implementation lands.
 - Keep documentation updated alongside feature work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
 | Variable | Purpose | Notes |
 | --- | --- | --- |
 | `DCC_STORAGE_ROOT` | Directory hosting application workspaces (`/opt/dockerstore` by default). | Must be writable by the DCC runtime and large enough to store cloned repositories and generated artifacts. |
+| `DCC_INSTALL_DIR` | Target directory for setup automation deployments (`/opt/dcc` by default). | Override when `/opt` is restricted or to stage multiple environments. |
 | `DCC_BASE_IMAGE` | NVIDIA-enabled Docker image tag for generated services. | Use images compatible with the NVIDIA Container Toolkit and target CUDA version. |
 | `DCC_DASHBOARD_PORT` | Exposed HTTP port for the operator dashboard. | Configure reverse proxy if public access is required. |
 | `DCC_REFRESH_INTERVAL` | Controls UI update cadence (e.g., websocket, SSE, polling). | Favor streaming mechanisms to avoid full page reloads. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,33 @@
+# Setup Automation
+
+The Docker Control Center repository ships with a Node.js setup utility that provisions runtime
+prerequisites, builds the placeholder UX, and deploys the artifacts under `/opt/dcc`.
+
+## Prerequisites
+- Node.js 18 or newer available on the PATH.
+- Root or sudo privileges (required when installing Docker packages or writing to `/opt`).
+- Debian/Ubuntu host. Automatic Docker installation is currently limited to apt-based systems.
+
+## Installation
+```bash
+# Run from the repository root
+node scripts/setup.js --install
+```
+
+The installer performs the following steps:
+1. Verifies that the Docker Engine and the `docker compose` plugin are reachable.
+2. Installs `docker.io` and `docker-compose-plugin` through `apt-get` when missing.
+3. Installs Node.js dependencies for the repository and runs the build pipeline.
+4. Takes a backup of any existing `/opt/dcc` deployment before deploying new assets.
+5. Copies the freshly built assets into `/opt/dcc/app` and writes an install state file for rollback.
+
+Set `DCC_INSTALL_DIR=/custom/path` to override the default target directory.
+
+## Rollback
+```bash
+node scripts/setup.js --rollback
+```
+
+Rollback restores the previous `/opt/dcc` snapshot (when one existed), removes files that the
+installer created, and uninstalls Docker components that the installer added. If no installation
+state file is present the command aborts without making changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "docker-control-center",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docker-control-center",
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "docker-control-center",
+  "version": "0.1.0",
+  "description": "Bootstrap utilities and UI scaffolding for the Docker Control Center core engine.",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "node scripts/build.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const distDir = path.join(projectRoot, 'dist');
+
+function ensureDist() {
+  if (!fs.existsSync(distDir)) {
+    fs.mkdirSync(distDir, { recursive: true });
+  }
+}
+
+function writePlaceholderAssets() {
+  const indexHtml = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Docker Control Center</title>
+    <style>
+      :root {
+        color-scheme: dark light;
+      }
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at top, #0d1117, #020409);
+        color: #f0f6fc;
+      }
+      .wrapper {
+        padding: 3rem;
+        background: rgba(13, 17, 23, 0.85);
+        border-radius: 1.5rem;
+        box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+        max-width: 640px;
+        text-align: center;
+      }
+      h1 {
+        font-size: clamp(2.5rem, 4vw, 3.5rem);
+        margin-bottom: 1rem;
+      }
+      p {
+        font-size: 1.1rem;
+        line-height: 1.6;
+        opacity: 0.85;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4rem 1rem;
+        border-radius: 999px;
+        background: rgba(56, 139, 253, 0.15);
+        color: #58a6ff;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <span class="badge">UX Deluxe</span>
+      <h1>Docker Control Center</h1>
+      <p>
+        The deluxe control surface for orchestrating GPU-first AI workloads. The production UI
+        build pipeline is not wired yet, but this placeholder demonstrates the build artifact
+        layout expected by the setup automation.
+      </p>
+    </div>
+  </body>
+</html>
+`;
+
+  fs.writeFileSync(path.join(distDir, 'index.html'), indexHtml, 'utf8');
+}
+
+function main() {
+  ensureDist();
+  writePlaceholderAssets();
+  console.log('✓ Generated deluxe placeholder UI in dist/.');
+}
+
+main();

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const DEFAULT_INSTALL_DIR = '/opt/dcc';
+const INSTALL_DIR = process.env.DCC_INSTALL_DIR || DEFAULT_INSTALL_DIR;
+const STATE_FILE = path.join(INSTALL_DIR, '.dcc-install-state.json');
+
+function usage() {
+  console.log(`Docker Control Center setup\n\n` +
+    `Usage:\n  node scripts/setup.js --install\n  node scripts/setup.js --rollback\n\n` +
+    `Environment:\n  DCC_INSTALL_DIR  Override target directory (default: ${DEFAULT_INSTALL_DIR})\n`);
+}
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: process.env,
+    ...options
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const joined = [command, ...args].join(' ');
+    throw new Error(`Command failed (${result.status}): ${joined}`);
+  }
+}
+
+function commandExists(binary) {
+  const result = spawnSync('which', [binary], { stdio: 'pipe' });
+  return result.status === 0;
+}
+
+function ensureDockerAvailability(state) {
+  const dockerPresent = commandExists('docker');
+  const composePresent = spawnSync('docker', ['compose', 'version'], { stdio: 'pipe' }).status === 0;
+
+  if (dockerPresent && composePresent) {
+    console.log('✓ Docker and docker compose plugin detected.');
+    state.installedDocker = false;
+    state.installedComposePlugin = false;
+    return;
+  }
+
+  const distro = detectDistro();
+  if (distro !== 'debian') {
+    throw new Error('Automatic Docker installation is only supported on Debian/Ubuntu hosts.');
+  }
+
+  console.log('⚙️  Installing Docker engine and compose plugin (requires sudo privileges)...');
+  runCommand('apt-get', ['update']);
+  runCommand('apt-get', ['install', '-y', 'docker.io', 'docker-compose-plugin']);
+
+  state.installedDocker = !dockerPresent;
+  state.installedComposePlugin = !composePresent;
+
+  const postCheck = spawnSync('docker', ['--version'], { stdio: 'pipe' });
+  if (postCheck.status !== 0) {
+    throw new Error('Docker installation appears to have failed.');
+  }
+  console.log('✓ Docker engine ready.');
+}
+
+function detectDistro() {
+  if (fs.existsSync('/etc/os-release')) {
+    const contents = fs.readFileSync('/etc/os-release', 'utf8');
+    if (/ID=debian|ID=ubuntu/.test(contents)) {
+      return 'debian';
+    }
+  }
+  return 'unknown';
+}
+
+function runBuildPipeline() {
+  console.log('⚙️  Installing Node dependencies...');
+  runCommand('npm', ['install'], { cwd: projectRoot });
+  console.log('⚙️  Running build...');
+  runCommand('npm', ['run', 'build'], { cwd: projectRoot });
+}
+
+function getProjectVersion() {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    return 'unknown';
+  }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return pkg.version || 'unknown';
+  } catch (error) {
+    console.warn('⚠️  Unable to read package version:', error.message);
+    return 'unknown';
+  }
+}
+
+function backupExistingInstall(state) {
+  if (!fs.existsSync(INSTALL_DIR)) {
+    state.createdInstallDir = true;
+    fs.mkdirSync(INSTALL_DIR, { recursive: true });
+    return;
+  }
+
+  const backupRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dcc-backup-'));
+  console.log(`⚠️  Existing install detected. Taking backup snapshot at ${backupRoot}`);
+  copyRecursive(INSTALL_DIR, backupRoot);
+  state.previousInstallBackup = backupRoot;
+}
+
+function copyRecursive(source, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  const entries = fs.readdirSync(source, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(source, entry.name);
+    const destPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      copyRecursive(srcPath, destPath);
+    } else if (entry.isSymbolicLink()) {
+      const link = fs.readlinkSync(srcPath);
+      fs.symlinkSync(link, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function deployArtifacts() {
+  const distDir = path.join(projectRoot, 'dist');
+  if (!fs.existsSync(distDir)) {
+    throw new Error('Build artifacts not found. Ensure npm run build succeeded.');
+  }
+
+  const targetDir = path.join(INSTALL_DIR, 'app');
+  if (fs.existsSync(targetDir)) {
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  }
+
+  copyRecursive(distDir, targetDir);
+  console.log(`✓ Deployed build artifacts to ${targetDir}`);
+}
+
+function writeState(state) {
+  fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
+}
+
+function readState() {
+  if (!fs.existsSync(STATE_FILE)) {
+    throw new Error('No install state found. Nothing to roll back.');
+  }
+  const raw = fs.readFileSync(STATE_FILE, 'utf8');
+  return JSON.parse(raw);
+}
+
+function rollback() {
+  console.log('🔄 Starting rollback...');
+  const state = readState();
+
+  if (state.installDir && state.installDir !== INSTALL_DIR) {
+    console.warn(`⚠️  Install directory mismatch. State references ${state.installDir} but current configuration targets ${INSTALL_DIR}. Proceeding with current target.`);
+  }
+
+  if (state.previousInstallBackup) {
+    console.log('↩️  Restoring previous install snapshot...');
+    if (fs.existsSync(INSTALL_DIR)) {
+      fs.rmSync(INSTALL_DIR, { recursive: true, force: true });
+    }
+    fs.mkdirSync(path.dirname(INSTALL_DIR), { recursive: true });
+    copyRecursive(state.previousInstallBackup, INSTALL_DIR);
+    console.log('✓ Previous install restored.');
+    fs.rmSync(state.previousInstallBackup, { recursive: true, force: true });
+  } else if (state.createdInstallDir && fs.existsSync(INSTALL_DIR)) {
+    console.log('🧹 Removing installation directory...');
+    fs.rmSync(INSTALL_DIR, { recursive: true, force: true });
+  }
+
+  if (state.installedDocker || state.installedComposePlugin) {
+    console.log('🧼 Removing Docker components that were installed by setup...');
+    runCommand('apt-get', ['remove', '-y', 'docker.io', 'docker-compose-plugin']);
+  }
+
+  fs.rmSync(STATE_FILE, { force: true });
+  console.log('✓ Rollback complete.');
+}
+
+function install() {
+  const state = {
+    timestamp: new Date().toISOString(),
+    installedDocker: false,
+    installedComposePlugin: false,
+    createdInstallDir: false,
+    installDir: INSTALL_DIR,
+    projectVersion: getProjectVersion()
+  };
+
+  ensureDockerAvailability(state);
+  runBuildPipeline();
+  backupExistingInstall(state);
+  deployArtifacts();
+  writeState(state);
+  console.log('✓ Install completed successfully.');
+  console.log(`ℹ️  Installation directory: ${INSTALL_DIR}`);
+  console.log('Run `node scripts/setup.js --rollback` to revert.');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--install')) {
+    install();
+    return;
+  }
+
+  if (args.includes('--rollback')) {
+    rollback();
+    return;
+  }
+
+  usage();
+  process.exitCode = 1;
+}
+
+main();

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+export function bootstrap() {
+  return {
+    status: 'ready',
+    message: 'Docker Control Center core engine bootstrap placeholder.'
+  };
+}


### PR DESCRIPTION
## Summary
- add a Node.js project scaffold with deluxe placeholder build output
- create setup automation that installs Docker requirements, runs the build, and deploys to /opt/dcc with rollback support
- document the new workflow in the README, configuration reference, and dedicated setup guide

## Testing
- npm run build

## Changelog
## [2025-10-04 11:45] Add automated setup pipeline
**Change Type:** Normal Change  
**Why:** Provide a reproducible Node.js-driven installer with rollback for the Docker Control Center environment.  
**What changed:** Added setup and build scripts, initialized the Node project scaffold, delivered a deluxe placeholder UI, and refreshed README plus setup documentation.  
**Impact:** Installer may install/remove Docker packages and deploy files under `/opt/dcc`; existing installs are snapshot before changes.  
**Testing:** `npm run build`  
**Docs:** README, docs/setup.md, docs/configuration.md updated.  
**Rollback Plan:** Run `node scripts/setup.js --rollback` or revert this commit.  
**Refs:** N/A


------
https://chatgpt.com/codex/tasks/task_e_68e0f6283a6c8333961593e122f55f72