### PR TITLE
setup: launch dashboard server and mirror git state

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -9,11 +9,21 @@
 **Refs:** N/A
 
 ## [2025-10-04 11:45] Add automated setup pipeline
+**Change Type:** Normal Change
+**Why:** Provide a reproducible Node.js-driven installer with rollback for the Docker Control Center environment.
+**What changed:** Added setup and build scripts, initialized the Node project scaffold, delivered a deluxe placeholder UI, and refreshed README plus setup documentation.
+**Impact:** Installer may install/remove Docker packages and deploy files under `/opt/dcc`; existing installs are snapshot before changes.
+**Testing:** `npm run build`
+**Docs:** README, docs/setup.md, docs/configuration.md updated.
+**Rollback Plan:** Run `node scripts/setup.js --rollback` or revert this commit.
+**Refs:** N/A
+
+## [2025-10-04 13:05] Auto-start dashboard and persist Git mirror
 **Change Type:** Normal Change  
-**Why:** Provide a reproducible Node.js-driven installer with rollback for the Docker Control Center environment.  
-**What changed:** Added setup and build scripts, initialized the Node project scaffold, delivered a deluxe placeholder UI, and refreshed README plus setup documentation.  
-**Impact:** Installer may install/remove Docker packages and deploy files under `/opt/dcc`; existing installs are snapshot before changes.  
+**Why:** Ensure the setup command provisions a runnable dashboard, retains the Git clone for updates, and creates required runtime directories.  
+**What changed:** Updated the installer to mirror the repository (including `.git`) into `/opt/dcc`, create runtime/log directories, stop previous servers before deploy, and launch a bundled static server. Added a reusable `serve.js` helper, documented the behavior, and exposed an `npm start` shortcut.  
+**Impact:** Installations now start a background Node server listening on `DCC_DASHBOARD_PORT`; ensure the port is free before running setup.  
 **Testing:** `npm run build`  
-**Docs:** README, docs/setup.md, docs/configuration.md updated.  
-**Rollback Plan:** Run `node scripts/setup.js --rollback` or revert this commit.  
+**Docs:** README.md, docs/setup.md updated.  
+**Rollback Plan:** Run `node scripts/setup.js --rollback` to stop the server and restore the snapshot, or revert the commit.  
 **Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A lightweight control plane for hosting GPU-accelerated AI applications on deman
 - Provision standardized NVIDIA-enabled Docker Compose stacks per application.
 - Mount isolated `/opt/dockerstore/<app>` workspaces into containers at `/app`.
 - Surface live container status and launch URLs on a responsive dashboard without manual refresh cycles.
-- Bootstrap environments with a Node.js installer that verifies Docker, builds the UX placeholder, and deploys artifacts to `/opt/dcc`.
+- Bootstrap environments with a Node.js installer that verifies Docker, builds the UX placeholder, mirrors the Git checkout (including `.git`) to `/opt/dcc`, and launches the bundled dashboard server.
 
 ## Quick Start
 ```bash
@@ -19,7 +19,7 @@ cd DockerControllCenter
 node scripts/setup.js --install
 ```
 
-Need to undo the setup? Execute `node scripts/setup.js --rollback` to restore the previous state.
+Need to undo the setup? Execute `node scripts/setup.js --rollback` to restore the previous state. The installer creates `/opt/dcc/app` for the built dashboard, `/opt/dcc/repo` with the full Git clone (ready for `git pull`), `/opt/dcc/data` for runtime files, and starts the static dashboard server on `http://localhost:${DCC_DASHBOARD_PORT:-8080}`.
 
 ## Setup Automation
 The installer orchestrates prerequisite checks, Docker package installation (via `apt-get` when

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,12 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
     requirements.txt (or custom name)
     docker-compose.yml (generated)
     metadata.json
+
+/opt/dcc/
+  app/   # Built dashboard assets served to operators
+  repo/  # Mirrored Git clone (with .git) for updates and maintenance
+  data/  # Runtime state and uploaded artifacts
+  logs/  # Dashboard server logs
 ```
 
 ## Networking

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,8 @@
 # Setup Automation
 
 The Docker Control Center repository ships with a Node.js setup utility that provisions runtime
-prerequisites, builds the placeholder UX, and deploys the artifacts under `/opt/dcc`.
+prerequisites, builds the placeholder UX, deploys the artifacts under `/opt/dcc`, mirrors the Git
+checkout (including `.git`) for future updates, and launches the bundled dashboard server.
 
 ## Prerequisites
 - Node.js 18 or newer available on the PATH.
@@ -18,8 +19,12 @@ The installer performs the following steps:
 1. Verifies that the Docker Engine and the `docker compose` plugin are reachable.
 2. Installs `docker.io` and `docker-compose-plugin` through `apt-get` when missing.
 3. Installs Node.js dependencies for the repository and runs the build pipeline.
-4. Takes a backup of any existing `/opt/dcc` deployment before deploying new assets.
-5. Copies the freshly built assets into `/opt/dcc/app` and writes an install state file for rollback.
+4. Gracefully stops any previously launched dashboard server and snapshots the existing `/opt/dcc` deployment.
+5. Copies the freshly built assets into `/opt/dcc/app`.
+6. Mirrors the Git checkout into `/opt/dcc/repo` (including `.git`) so `git pull` can fetch updates in-place.
+7. Creates `/opt/dcc/data` and `/opt/dcc/logs` for runtime use and audit trails.
+8. Launches the static dashboard server from the mirrored repository on `DCC_DASHBOARD_PORT` (default: 8080).
+9. Writes an install state file for rollback (including server PID and log path metadata).
 
 Set `DCC_INSTALL_DIR=/custom/path` to override the default target directory.
 
@@ -28,6 +33,6 @@ Set `DCC_INSTALL_DIR=/custom/path` to override the default target directory.
 node scripts/setup.js --rollback
 ```
 
-Rollback restores the previous `/opt/dcc` snapshot (when one existed), removes files that the
-installer created, and uninstalls Docker components that the installer added. If no installation
-state file is present the command aborts without making changes.
+Rollback restores the previous `/opt/dcc` snapshot (when one existed), stops the running dashboard
+server, removes files that the installer created, and uninstalls Docker components that the
+installer added. If no installation state file is present the command aborts without making changes.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "build": "node scripts/build.js"
+    "build": "node scripts/build.js",
+    "start": "node scripts/serve.js --root dist"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const options = {
+    root: process.cwd(),
+    port: parseInt(process.env.DCC_DASHBOARD_PORT || '8080', 10)
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--root') {
+      options.root = path.resolve(args[i + 1] || options.root);
+      i += 1;
+    } else if (arg === '--port') {
+      const next = args[i + 1];
+      if (!next) continue;
+      options.port = parseInt(next, 10);
+      i += 1;
+    }
+  }
+
+  return options;
+}
+
+function sendResponse(res, status, body, headers = {}) {
+  res.writeHead(status, {
+    'Content-Length': Buffer.byteLength(body),
+    ...headers
+  });
+  res.end(body);
+}
+
+function createServer(root) {
+  return http.createServer((req, res) => {
+    try {
+      const parsedUrl = url.parse(req.url || '/');
+      const sanitizedPath = path.normalize(parsedUrl.pathname || '/').replace(/^\/+/, '');
+      let requestedPath = path.join(root, sanitizedPath);
+
+      if (!requestedPath.startsWith(root)) {
+        sendResponse(res, 403, 'Forbidden');
+        return;
+      }
+
+      if (fs.existsSync(requestedPath) && fs.statSync(requestedPath).isDirectory()) {
+        requestedPath = path.join(requestedPath, 'index.html');
+      }
+
+      if (!fs.existsSync(requestedPath)) {
+        sendResponse(res, 404, 'Not Found');
+        return;
+      }
+
+      const stream = fs.createReadStream(requestedPath);
+      stream.on('error', (error) => {
+        console.error('Failed to stream asset:', error);
+        if (!res.headersSent) {
+          sendResponse(res, 500, 'Internal Server Error');
+        } else {
+          res.destroy(error);
+        }
+      });
+      stream.pipe(res);
+    } catch (error) {
+      console.error('Unhandled server error:', error);
+      if (!res.headersSent) {
+        sendResponse(res, 500, 'Internal Server Error');
+      } else {
+        res.destroy(error);
+      }
+    }
+  });
+}
+
+function main() {
+  const options = parseArgs();
+  const root = path.resolve(options.root);
+  if (!fs.existsSync(root)) {
+    console.error(`Static root ${root} does not exist.`);
+    process.exit(1);
+  }
+
+  const server = createServer(root);
+  server.listen(options.port, () => {
+    console.log(`Dashboard server listening on http://0.0.0.0:${options.port}`);
+    console.log(`Serving static assets from ${root}`);
+  });
+
+  const shutdown = () => {
+    server.close(() => {
+      console.log('Dashboard server stopped.');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+main();

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,6 +11,7 @@ const projectRoot = path.resolve(__dirname, '..');
 const DEFAULT_INSTALL_DIR = '/opt/dcc';
 const INSTALL_DIR = process.env.DCC_INSTALL_DIR || DEFAULT_INSTALL_DIR;
 const STATE_FILE = path.join(INSTALL_DIR, '.dcc-install-state.json');
+const DASHBOARD_PORT = parseInt(process.env.DCC_DASHBOARD_PORT || '8080', 10);
 
 function usage() {
   console.log(`Docker Control Center setup\n\n` +
@@ -114,14 +115,18 @@ function backupExistingInstall(state) {
   state.previousInstallBackup = backupRoot;
 }
 
-function copyRecursive(source, destination) {
+function copyRecursive(source, destination, options = {}) {
+  const { shouldSkip } = options;
   fs.mkdirSync(destination, { recursive: true });
   const entries = fs.readdirSync(source, { withFileTypes: true });
   for (const entry of entries) {
+    if (shouldSkip && shouldSkip(source, entry)) {
+      continue;
+    }
     const srcPath = path.join(source, entry.name);
     const destPath = path.join(destination, entry.name);
     if (entry.isDirectory()) {
-      copyRecursive(srcPath, destPath);
+      copyRecursive(srcPath, destPath, options);
     } else if (entry.isSymbolicLink()) {
       const link = fs.readlinkSync(srcPath);
       fs.symlinkSync(link, destPath);
@@ -146,6 +151,76 @@ function deployArtifacts() {
   console.log(`✓ Deployed build artifacts to ${targetDir}`);
 }
 
+function syncRepositoryMirror() {
+  const repoTarget = path.join(INSTALL_DIR, 'repo');
+  if (fs.existsSync(repoTarget)) {
+    fs.rmSync(repoTarget, { recursive: true, force: true });
+  }
+
+  const skipNames = new Set(['node_modules', 'dist']);
+  copyRecursive(projectRoot, repoTarget, {
+    shouldSkip: (_source, entry) => skipNames.has(entry.name)
+  });
+
+  console.log(`✓ Repository mirror (including .git) synced to ${repoTarget}`);
+  return repoTarget;
+}
+
+function ensureRuntimeDirectories() {
+  const dataDir = path.join(INSTALL_DIR, 'data');
+  const logDir = path.join(INSTALL_DIR, 'logs');
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(logDir, { recursive: true });
+  console.log(`✓ Runtime directories ready under ${INSTALL_DIR}`);
+  return { dataDir, logDir };
+}
+
+function startDashboardServer(state, repoDir, logDir) {
+  const serverScript = path.join(repoDir, 'scripts', 'serve.js');
+  if (!fs.existsSync(serverScript)) {
+    throw new Error('Dashboard server script not found. Expected scripts/serve.js in repo mirror.');
+  }
+
+  const logPath = path.join(logDir, 'dashboard.log');
+  const out = fs.openSync(logPath, 'a');
+  const err = fs.openSync(logPath, 'a');
+
+  const child = spawn('node', [serverScript, '--root', path.join(INSTALL_DIR, 'app'), '--port', String(DASHBOARD_PORT)], {
+    cwd: repoDir,
+    detached: true,
+    stdio: ['ignore', out, err],
+    env: {
+      ...process.env,
+      DCC_INSTALL_DIR: INSTALL_DIR,
+      DCC_DASHBOARD_PORT: String(DASHBOARD_PORT)
+    }
+  });
+
+  child.unref();
+  fs.closeSync(out);
+  fs.closeSync(err);
+  state.serverPid = child.pid;
+  state.serverPort = DASHBOARD_PORT;
+  state.serverLog = logPath;
+  console.log(`✓ Dashboard server started on port ${DASHBOARD_PORT} (PID ${child.pid}).`);
+}
+
+function stopExistingServer() {
+  if (!fs.existsSync(STATE_FILE)) {
+    return;
+  }
+
+  try {
+    const previous = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+    if (previous.serverPid) {
+      process.kill(previous.serverPid, 'SIGTERM');
+      console.log(`↩️  Stopped previous dashboard server (PID ${previous.serverPid}).`);
+    }
+  } catch (error) {
+    console.warn('⚠️  Unable to stop previous server:', error.message);
+  }
+}
+
 function writeState(state) {
   fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
   fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
@@ -162,6 +237,15 @@ function readState() {
 function rollback() {
   console.log('🔄 Starting rollback...');
   const state = readState();
+
+  if (state.serverPid) {
+    try {
+      process.kill(state.serverPid, 'SIGTERM');
+      console.log(`🛑 Dashboard server process ${state.serverPid} terminated.`);
+    } catch (error) {
+      console.warn(`⚠️  Failed to terminate dashboard server ${state.serverPid}: ${error.message}`);
+    }
+  }
 
   if (state.installDir && state.installDir !== INSTALL_DIR) {
     console.warn(`⚠️  Install directory mismatch. State references ${state.installDir} but current configuration targets ${INSTALL_DIR}. Proceeding with current target.`);
@@ -202,8 +286,19 @@ function install() {
 
   ensureDockerAvailability(state);
   runBuildPipeline();
+  stopExistingServer();
   backupExistingInstall(state);
   deployArtifacts();
+  const repoDir = syncRepositoryMirror();
+  const runtimeDirs = ensureRuntimeDirectories();
+  state.repoDir = repoDir;
+  state.dataDir = runtimeDirs.dataDir;
+  state.logDir = runtimeDirs.logDir;
+  try {
+    startDashboardServer(state, repoDir, runtimeDirs.logDir);
+  } catch (error) {
+    console.warn(`⚠️  Dashboard server failed to start: ${error.message}`);
+  }
   writeState(state);
   console.log('✓ Install completed successfully.');
   console.log(`ℹ️  Installation directory: ${INSTALL_DIR}`);


### PR DESCRIPTION
## Why
- ensure the installer leaves a runnable dashboard after execution
- retain the cloned repository (including .git) under /opt/dcc for updates
- create runtime directories so data and logs no longer disappear between runs

## What
- mirror the repository into /opt/dcc/repo, create data/log folders, and start a detached dashboard server during install
- add a lightweight static server helper and npm start alias for local operation
- document the new install behavior across README, setup, and configuration guides

## Impact
- setup now launches a background Node process bound to DCC_DASHBOARD_PORT; ensure the port is available before installing

## Testing
- `npm run build`

## Docs
- README.md
- docs/setup.md
- docs/configuration.md

## Changelog
## [2025-10-04 13:05] Auto-start dashboard and persist Git mirror
**Change Type:** Normal Change  
**Why:** Ensure the setup command provisions a runnable dashboard, retains the Git clone for updates, and creates required runtime directories.  
**What changed:** Updated the installer to mirror the repository (including `.git`) into `/opt/dcc`, create runtime/log directories, stop previous servers before deploy, and launch a bundled static server. Added a reusable `serve.js` helper, documented the behavior, and exposed an `npm start` shortcut.  
**Impact:** Installations now start a background Node server listening on `DCC_DASHBOARD_PORT`; ensure the port is free before running setup.  
**Testing:** `npm run build`  
**Docs:** README.md, docs/setup.md updated.  
**Rollback Plan:** Run `node scripts/setup.js --rollback` to stop the server and restore the snapshot, or revert the commit.  
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e0f896d3f88333918b24d07434eeb8