### PR TITLE
core: clear demo seed data and add open app shortcut

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -39,11 +39,21 @@
 **Refs:** N/A
 
 ## [2025-10-04 16:05] Introduce lifecycle manager for app onboarding
+**Change Type:** Normal Change
+**Why:** Begin implementing the documented Add App workflow by providing reusable services for validation, provisioning, and installation.
+**What changed:** Added an `AppLifecycleManager` with validation helpers, Prisma-driven registration, Git sync, and Compose generation plus Docker orchestration; extended the Prisma schema with workspace slugs and start commands; created unit tests, scripts, and documentation for the new framework.
+**Impact:** Node runtime can now register/install apps via the lifecycle manager; Prisma schema changes require running the new migration.
+**Testing:** `npm test`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert the commit and drop the added Prisma migration.
+**Refs:** N/A
+
+## [2025-10-04 18:30] Clear demo seed data and add open app control
 **Change Type:** Normal Change  
-**Why:** Begin implementing the documented Add App workflow by providing reusable services for validation, provisioning, and installation.  
-**What changed:** Added an `AppLifecycleManager` with validation helpers, Prisma-driven registration, Git sync, and Compose generation plus Docker orchestration; extended the Prisma schema with workspace slugs and start commands; created unit tests, scripts, and documentation for the new framework.  
-**Impact:** Node runtime can now register/install apps via the lifecycle manager; Prisma schema changes require running the new migration.  
-**Testing:** `npm test`  
+**Why:** Allow operators to populate the system with accurate records and expose a quick link to launched apps.  
+**What changed:** Updated the Prisma seed to delete legacy demo entries without inserting new ones, refreshed the dashboard preview to highlight empty states and the new “Open App” action, and revised docs to reflect the clean-start workflow.  
+**Impact:** Running the seed now removes the old Stable Diffusion demo; UI previews show zero preloaded apps/templates and surface the Open App control.  
+**Testing:** `npm test`, `npm run build`  
 **Docs:** README.md, docs/architecture-overview.md updated.  
-**Rollback Plan:** Revert the commit and drop the added Prisma migration.  
+**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate placeholder assets.  
 **Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight control plane for hosting GPU-accelerated AI applications on deman
 ## Features
 - Guided "Add App" dialog prepared for validating metadata and provisioning GPU-ready Docker Compose stacks.
 - Marketplace dialog that surfaces previously installed apps as reusable templates stored in Prisma + SQLite.
-- Application fleet table with start/stop/reinstall/deinstall controls and traffic-light health signals (red/offline, yellow/installing, green/online/port reachable).
+- Application fleet table with open-app quick links, start/stop/reinstall/deinstall controls, and traffic-light health signals (red/offline, yellow/installing, green/online/port reachable).
 - Isolated `/opt/dockerstore/<app>` workspaces mounted into containers at `/app`.
 - Node.js installer that verifies Docker, runs Prisma migrations/seeding, builds the deluxe dashboard preview, mirrors the Git checkout (including `.git`) to `/opt/dcc`, and launches the bundled dashboard server.
 - App lifecycle framework that validates onboarding payloads, derives deterministic workspace slugs, syncs Git repositories, renders Docker Compose definitions, and drives `docker compose up -d` to install workloads.
@@ -78,7 +78,7 @@ The manager enforces validation rules, derives a sanitized `workspaceSlug`, writ
 ### Database
 
 - Prisma schema lives in `prisma/schema.prisma` and targets SQLite by default.
-- Seed data (`prisma/seed.js`) provisions a **Stable Diffusion Demo** entry so the marketplace and fleet table render meaningful placeholders.
+- Seed routine (`prisma/seed.js`) now removes legacy demo entries so you always start from a clean slate before onboarding your own apps.
 - Override the `DATABASE_URL` environment variable to point at production-grade storage. The setup automation falls back to `file:/opt/dcc/data/dcc.sqlite` when none is provided.
 
 Detailed lifecycle and automation guidance lives in [`docs/architecture-overview.md`](docs/architecture-overview.md).

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -34,7 +34,7 @@
 
 5. **Marketplace Reuse**
    - Completed installs can promote their metadata into `MarketplaceTemplate` records.
-   - The marketplace dialog surfaces seeded templates (including the Stable Diffusion demo) for rapid onboarding.
+   - The marketplace dialog lists templates created from successful installs without bundling demo data by default.
    - Templates store summaries, repository URLs, default ports, GPU requirements, and refer back to the originating app when available.
 
 ## Component Responsibilities

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -3,46 +3,25 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  const demoApp = await prisma.app.upsert({
-    where: { name: 'Stable Diffusion Demo' },
-    update: {
-      status: 'RUNNING',
-      lastSeenAt: new Date(),
-      notes: 'Demo workload reachable on the configured port for UI preview.',
-      workspaceSlug: 'stable-diffusion-demo',
-      startCommand: 'python webui.py --listen'
-    },
-    create: {
-      name: 'Stable Diffusion Demo',
-      workspaceSlug: 'stable-diffusion-demo',
-      repositoryUrl: 'https://github.com/placeholder/stable-diffusion-demo.git',
-      port: 7860,
-      status: 'RUNNING',
-      healthEndpoint: 'http://localhost:7860/health',
-      lastSeenAt: new Date(),
-      notes: 'Demo workload reachable on the configured port for UI preview.',
-      startCommand: 'python webui.py --listen'
+  const removedTemplates = await prisma.marketplaceTemplate.deleteMany({
+    where: {
+      name: {
+        in: ['Stable Diffusion Demo']
+      }
     }
   });
 
-  await prisma.marketplaceTemplate.upsert({
-    where: { name: 'Stable Diffusion Demo' },
-    update: {
-      summary: 'Reusable GPU image synthesis stack with txt2img and img2img presets.',
-      repositoryUrl: demoApp.repositoryUrl,
-      defaultPort: demoApp.port ?? 7860,
-      onboardingHints: 'Requires 8GB VRAM. Uses AUTOMATIC1111 baseline compose template.',
-      sourceAppId: demoApp.id
-    },
-    create: {
-      name: 'Stable Diffusion Demo',
-      summary: 'Reusable GPU image synthesis stack with txt2img and img2img presets.',
-      repositoryUrl: demoApp.repositoryUrl,
-      defaultPort: demoApp.port ?? 7860,
-      onboardingHints: 'Requires 8GB VRAM. Uses AUTOMATIC1111 baseline compose template.',
-      sourceAppId: demoApp.id
+  const removedApps = await prisma.app.deleteMany({
+    where: {
+      name: {
+        in: ['Stable Diffusion Demo']
+      }
     }
   });
+
+  console.log(
+    `✓ Cleared ${removedApps.count} demo app(s) and ${removedTemplates.count} template(s). Database is ready for fresh onboarding.`
+  );
 }
 
 main()

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -370,6 +370,27 @@ function writePlaceholderAssets() {
         background: rgba(240, 246, 252, 0.08);
       }
 
+      .empty-row td {
+        padding: 2rem 1rem;
+        text-align: center;
+      }
+
+      .empty-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .empty-state strong {
+        font-size: 1rem;
+      }
+
+      button[disabled] {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
       footer {
         text-align: center;
         color: rgba(240, 246, 252, 0.4);
@@ -416,19 +437,19 @@ function writePlaceholderAssets() {
           <div class="stat-grid">
             <div class="stat-card">
               <span class="label">Running</span>
-              <span class="value">1</span>
+              <span class="value">0</span>
             </div>
             <div class="stat-card">
               <span class="label">Starting</span>
-              <span class="value">1</span>
+              <span class="value">0</span>
             </div>
             <div class="stat-card">
               <span class="label">Stopped</span>
-              <span class="value">2</span>
+              <span class="value">0</span>
             </div>
             <div class="stat-card">
               <span class="label">Marketplace Templates</span>
-              <span class="value">4</span>
+              <span class="value">0</span>
             </div>
           </div>
         </article>
@@ -468,10 +489,18 @@ function writePlaceholderAssets() {
             </tr>
           </thead>
           <tbody>
+            <tr class="empty-row">
+              <td colspan="5">
+                <div class="empty-state">
+                  <strong>No applications registered yet.</strong>
+                  <p class="table-hint">Use Add App or promote a marketplace template to see entries here.</p>
+                </div>
+              </td>
+            </tr>
             <tr>
               <td>
-                <strong>Stable Diffusion Demo</strong>
-                <div class="table-hint">Seeded from Prisma for preview.</div>
+                <strong>Example GPU Inference</strong>
+                <div class="table-hint">This preview row illustrates the controls available once an app is running.</div>
               </td>
               <td>
                 <span class="status-pill" data-status="RUNNING">
@@ -483,49 +512,9 @@ function writePlaceholderAssets() {
               <td>Online • port reachable</td>
               <td>
                 <div class="table-actions">
-                  <button class="primary">Stop</button>
-                  <button>Restart</button>
-                  <button>Deinstall</button>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <strong>LangChain Assistant</strong>
-                <div class="table-hint">Provisioning compose stack…</div>
-              </td>
-              <td>
-                <span class="status-pill" data-status="STARTING">
-                  <span class="status-dot"></span>
-                  Starting
-                </span>
-              </td>
-              <td>5050</td>
-              <td>Awaiting health check</td>
-              <td>
-                <div class="table-actions">
+                  <button class="primary">Open App</button>
                   <button>Stop</button>
-                  <button>Deinstall</button>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <strong>Finetune Lab</strong>
-                <div class="table-hint">Offline — ready for reinstall.</div>
-              </td>
-              <td>
-                <span class="status-pill" data-status="STOPPED">
-                  <span class="status-dot"></span>
-                  Stopped
-                </span>
-              </td>
-              <td>9090</td>
-              <td>Last seen 2 hours ago</td>
-              <td>
-                <div class="table-actions">
-                  <button class="primary">Start</button>
-                  <button>Reinstall</button>
+                  <button>Restart</button>
                   <button>Deinstall</button>
                 </div>
               </td>
@@ -570,7 +559,7 @@ function writePlaceholderAssets() {
             Marketplace Template
             <select name="template">
               <option value="">Create new template</option>
-              <option value="stable-diffusion">Stable Diffusion Demo</option>
+              <option value="" disabled>No saved templates yet</option>
             </select>
           </label>
         </div>
@@ -593,35 +582,18 @@ function writePlaceholderAssets() {
         <div class="marketplace-grid">
           <div class="marketplace-card">
             <div class="tag-list">
-              <span>GPU</span>
-              <span>Seeded</span>
+              <span>Empty</span>
             </div>
-            <h3>Stable Diffusion Demo</h3>
-            <p class="table-hint">Txt2img + img2img baseline with AUTOMATIC1111 UI. Port 7860.</p>
-            <button type="submit">Deploy Template</button>
+            <h3>No templates yet</h3>
+            <p class="table-hint">Templates appear after promoting a successfully installed app.</p>
+            <button type="submit" disabled>Deploy Template</button>
           </div>
           <div class="marketplace-card">
             <div class="tag-list">
-              <span>LLM</span>
+              <span>Preview</span>
             </div>
-            <h3>LangChain Assistant</h3>
-            <p class="table-hint">Boilerplate conversational agent with Redis memory.</p>
-            <button type="submit">Deploy Template</button>
-          </div>
-          <div class="marketplace-card">
-            <div class="tag-list">
-              <span>Vision</span>
-            </div>
-            <h3>DreamBooth Trainer</h3>
-            <p class="table-hint">Interactive fine-tuning workflow. Requires >= 16GB VRAM.</p>
-            <button type="submit">Deploy Template</button>
-          </div>
-          <div class="marketplace-card">
-            <div class="tag-list">
-              <span>Inference</span>
-            </div>
-            <h3>Segment Anything</h3>
-            <p class="table-hint">Pre-configured SAM service behind FastAPI.</p>
+            <h3>Example Template</h3>
+            <p class="table-hint">Once templates exist, operators can launch new installs in one click.</p>
             <button type="submit">Deploy Template</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the Stable Diffusion demo seed so databases start empty and clean up any lingering demo entries
- refresh the dashboard preview to show empty states, add the Open App action, and update marketplace copy
- document the new behaviour in the README, architecture overview, and changelog

## Testing
- `npm test`
- `npm run build`

## Changelog
```
## [2025-10-04 18:30] Clear demo seed data and add open app control
**Change Type:** Normal Change  
**Why:** Allow operators to populate the system with accurate records and expose a quick link to launched apps.  
**What changed:** Updated the Prisma seed to delete legacy demo entries without inserting new ones, refreshed the dashboard preview to highlight empty states and the new “Open App” action, and revised docs to reflect the clean-start workflow.  
**Impact:** Running the seed now removes the old Stable Diffusion demo; UI previews show zero preloaded apps/templates and surface the Open App control.  
**Testing:** `npm test`, `npm run build`  
**Docs:** README.md, docs/architecture-overview.md updated.  
**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate placeholder assets.  
**Refs:** N/A
```

------
https://chatgpt.com/codex/tasks/task_e_68e11059494c83338d5c39a2377dbe9d