### PR TITLE
core: add docker telemetry orchestrator and settings persistence

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -49,11 +49,21 @@
 **Refs:** N/A
 
 ## [2025-10-04 18:30] Clear demo seed data and add open app control
+**Change Type:** Normal Change
+**Why:** Allow operators to populate the system with accurate records and expose a quick link to launched apps.
+**What changed:** Updated the Prisma seed to delete legacy demo entries without inserting new ones, refreshed the dashboard preview to highlight empty states and the new “Open App” action, and revised docs to reflect the clean-start workflow.
+**Impact:** Running the seed now removes the old Stable Diffusion demo; UI previews show zero preloaded apps/templates and surface the Open App control.
+**Testing:** `npm test`, `npm run build`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate placeholder assets.
+**Refs:** N/A
+
+## [2025-10-04 19:30] Add Docker orchestrator telemetry and settings persistence
 **Change Type:** Normal Change  
-**Why:** Allow operators to populate the system with accurate records and expose a quick link to launched apps.  
-**What changed:** Updated the Prisma seed to delete legacy demo entries without inserting new ones, refreshed the dashboard preview to highlight empty states and the new “Open App” action, and revised docs to reflect the clean-start workflow.  
-**Impact:** Running the seed now removes the old Stable Diffusion demo; UI previews show zero preloaded apps/templates and surface the Open App control.  
-**Testing:** `npm test`, `npm run build`  
-**Docs:** README.md, docs/architecture-overview.md updated.  
-**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate placeholder assets.  
+**Why:** Provide database-backed container telemetry and configurable Open App URLs without relying on environment files.  
+**What changed:** Introduced a `DockerOrchestrator` service with tests, expanded the Prisma schema (AppSettings, DockerContainerState, openAppBaseUrl), added migrations/seeds, and updated docs plus README to describe telemetry, marketplace persistence, and the mini settings tab.  
+**Impact:** Requires running the new Prisma migration; telemetry and custom host links now persist in the database.  
+**Testing:** `npm test`  
+**Docs:** README.md, docs/architecture-overview.md, docs/configuration.md updated.  
+**Rollback Plan:** Revert the commit and roll back Prisma migration `20251004190000_add_docker_orchestrator`.  
 **Refs:** N/A

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -26,11 +26,13 @@
    - Monitor container logs, GPU resource allocation, and health checks.
    - Expose the configured port on the host, optionally with HTTPS termination upstream.
 
-4. **Dashboard Visibility**
-   - Reflect container status changes through websockets or server-sent events to avoid full refreshes.
-   - Provide quick links to the hosted application and troubleshooting logs.
+4. **Telemetry + Dashboard Visibility**
+   - The `DockerOrchestrator` polls `docker ps`, `docker inspect`, and `docker stats` to capture runtime state for each managed container.
+   - Telemetry snapshots are persisted through Prisma's `DockerContainerState` model so dashboard consumers read from the central database instead of environment files.
+   - App records receive status updates (e.g., `RUNNING`, `FAILED`, `STOPPED`) and `lastSeenAt` timestamps whenever telemetry cycles complete.
+   - Provide quick links to the hosted application and troubleshooting logs, including custom “Open App” URLs sourced from the database-backed `AppSettings` model.
    - Support lifecycle actions: start, stop, reinstall, deinstall, restart.
-   - Display a traffic-light health indicator using Prisma-tracked status enums (`RUNNING`, `STARTING`, `STOPPED`) combined with periodic port reachability checks.
+   - Display a traffic-light health indicator using Prisma-tracked status enums (`RUNNING`, `STARTING`, `STOPPED`) combined with periodic port reachability checks and orchestrator health data.
 
 5. **Marketplace Reuse**
    - Completed installs can promote their metadata into `MarketplaceTemplate` records.
@@ -43,6 +45,7 @@
 | Web Frontend | Responsive UI for onboarding dialogs, marketplace browsing, status table, and lifecycle actions. Employs real-time updates without constant refreshes. |
 | API / Backend | Validates submissions, manages Git interactions, renders Compose templates, orchestrates lifecycle actions, and surfaces health probes. |
 | Lifecycle Manager | Node.js service (`AppLifecycleManager`) that validates inputs, derives workspace slugs, syncs Git repositories, writes Compose manifests, and executes `docker compose up -d` while updating Prisma status fields. |
+| Telemetry Orchestrator | Background service (`DockerOrchestrator`) that polls Docker, stores normalized telemetry in `DockerContainerState`, and hydrates dashboard-ready payloads including "Open App" URLs from `AppSettings`. |
 | Worker / Runner | Executes repository cloning, dependency installation, compose orchestration, and port health checks with GPU support. |
 | Storage Layer | Hosts `/opt/dockerstore` directories and durable metadata (Prisma-managed SQLite by default). Stores both active apps and marketplace templates. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
 | `DCC_LOG_LEVEL` | Logging verbosity (`info`, `debug`, etc.). | Increase temporarily for troubleshooting. |
 | `DATABASE_URL` | Prisma connection string. Defaults to SQLite under `/opt/dcc/data/dcc.sqlite`. | Point at PostgreSQL/MySQL for production or keep SQLite for embedded deployments. |
 
+## Database-backed Settings
+- Operator-facing preferences such as custom "Open App" hosts are persisted via Prisma (`AppSettings.openAppBaseUrl`).
+- Container telemetry snapshots (status, health, resource metrics) live in `DockerContainerState`, allowing the UI to render dashboards without referencing environment files.
+- Marketplace templates continue to live in the database (`MarketplaceTemplate`), keeping all runtime metadata centralized.
+
 ## File System Layout
 ```
 /opt/dockerstore/
@@ -44,4 +49,5 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
 
 ## Observability
 - Forward container logs to centralized logging (ELK, Loki).
+- The `DockerOrchestrator` already polls Docker for lifecycle/health data; surface additional metrics by exporting the `DockerContainerState` table to Prometheus/Grafana if needed.
 - Emit metrics for container lifecycle events, GPU usage, and onboarding errors.

--- a/prisma/migrations/20251004190000_add_docker_orchestrator/migration.sql
+++ b/prisma/migrations/20251004190000_add_docker_orchestrator/migration.sql
@@ -1,0 +1,34 @@
+-- AlterTable
+ALTER TABLE "App" ADD COLUMN "openAppBaseUrl" TEXT;
+
+-- CreateTable
+CREATE TABLE "AppSettings" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "appId" TEXT NOT NULL,
+  "openAppBaseUrl" TEXT,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "AppSettings_appId_fkey" FOREIGN KEY ("appId") REFERENCES "App"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DockerContainerState" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "appId" TEXT NOT NULL,
+  "containerId" TEXT NOT NULL,
+  "containerName" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "health" TEXT,
+  "state" TEXT,
+  "metrics" TEXT,
+  "lastObservedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "DockerContainerState_appId_fkey" FOREIGN KEY ("appId") REFERENCES "App"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AppSettings_appId_key" ON "AppSettings"("appId");
+CREATE UNIQUE INDEX "DockerContainerState_containerId_key" ON "DockerContainerState"("containerId");
+CREATE UNIQUE INDEX "DockerContainerState_appId_key" ON "DockerContainerState"("appId");
+CREATE INDEX "DockerContainerState_appId_updatedAt_idx" ON "DockerContainerState"("appId", "updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,10 @@ model App {
   updatedAt       DateTime   @updatedAt
   lastSeenAt      DateTime?
   notes           String?
+  openAppBaseUrl  String?
   marketplaceTemplates MarketplaceTemplate[]
+  settings        AppSettings?
+  containerStates DockerContainerState[]
 }
 
 model MarketplaceTemplate {
@@ -35,4 +38,31 @@ model MarketplaceTemplate {
   sourceApp       App?       @relation(fields: [sourceAppId], references: [id])
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+}
+
+model AppSettings {
+  id             String   @id @default(cuid())
+  appId          String   @unique
+  openAppBaseUrl String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  app            App      @relation(fields: [appId], references: [id], onDelete: Cascade)
+}
+
+model DockerContainerState {
+  id             String   @id @default(cuid())
+  appId          String
+  containerId    String   @unique
+  containerName  String
+  status         String
+  health         String?
+  state          Json?
+  metrics        Json?
+  lastObservedAt DateTime @default(now())
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  app            App      @relation(fields: [appId], references: [id], onDelete: Cascade)
+
+  @@index([appId, updatedAt])
+  @@unique([appId])
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -3,6 +3,8 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
+  await prisma.dockerContainerState.deleteMany({});
+  await prisma.appSettings.deleteMany({});
   const removedTemplates = await prisma.marketplaceTemplate.deleteMany({
     where: {
       name: {
@@ -20,7 +22,7 @@ async function main() {
   });
 
   console.log(
-    `✓ Cleared ${removedApps.count} demo app(s) and ${removedTemplates.count} template(s). Database is ready for fresh onboarding.`
+    `✓ Cleared ${removedApps.count} demo app(s), ${removedTemplates.count} template(s), and reset orchestrator state.`
   );
 }
 

--- a/src/framework/dockerOrchestrator.js
+++ b/src/framework/dockerOrchestrator.js
@@ -1,0 +1,357 @@
+import { setInterval as createInterval, clearInterval as clearTimer } from 'node:timers';
+import { spawn } from 'node:child_process';
+import { deriveWorkspaceSlug } from './validation.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+function parseJsonLines(output) {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        const failure = new Error('Failed to parse docker CLI JSON output.');
+        failure.cause = error;
+        failure.line = line;
+        throw failure;
+      }
+    });
+}
+
+function mapStatsByContainerName(statsOutput) {
+  if (!statsOutput) {
+    return new Map();
+  }
+
+  const map = new Map();
+
+  for (const entry of parseJsonLines(statsOutput)) {
+    if (entry.Name) {
+      map.set(entry.Name, entry);
+    }
+  }
+
+  return map;
+}
+
+function toUpperSafe(value) {
+  return typeof value === 'string' ? value.toUpperCase() : value ?? null;
+}
+
+async function inspectContainer(commandRunner, containerId) {
+  const { stdout } = await commandRunner('docker', ['inspect', containerId]);
+  const parsed = JSON.parse(stdout);
+  return Array.isArray(parsed) ? parsed[0] ?? null : parsed;
+}
+
+function resolveContainerName(app) {
+  const slug = app.workspaceSlug ?? deriveWorkspaceSlug(app.name);
+  return `dcc-${slug}`;
+}
+
+function resolveStatus(inspectData, psSummary) {
+  const raw =
+    inspectData?.State?.Status ??
+    inspectData?.State?.State ??
+    psSummary?.State ??
+    psSummary?.Status ??
+    'unknown';
+  return toUpperSafe(raw);
+}
+
+function resolveHealth(inspectData, psSummary) {
+  const raw = inspectData?.State?.Health?.Status ?? psSummary?.Health;
+  return raw ? raw.toUpperCase() : null;
+}
+
+function sanitizeMetrics(entry) {
+  if (!entry) {
+    return null;
+  }
+
+  return {
+    cpuPercent: entry.CPUPerc ? Number.parseFloat(entry.CPUPerc.replace('%', '')) : null,
+    memoryUsage: entry.MemUsage ?? null,
+    memoryPercent: entry.MemPerc ? Number.parseFloat(entry.MemPerc.replace('%', '')) : null,
+    networkIO: entry.NetIO ?? null,
+    blockIO: entry.BlockIO ?? null,
+    pids: entry.PIDs ? Number.parseInt(entry.PIDs, 10) : null
+  };
+}
+
+function createDefaultRunner(logger) {
+  return (command, args = [], options = {}) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...options
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString();
+        logger?.debug?.(data.toString());
+      });
+
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString();
+        logger?.debug?.(data.toString());
+      });
+
+      child.on('error', (error) => reject(error));
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          const failure = new Error(`Command failed: ${command}`);
+          failure.code = code;
+          failure.stderr = stderr;
+          reject(failure);
+        }
+      });
+    });
+}
+
+export class DockerOrchestrator {
+  constructor({
+    prisma,
+    commandRunner,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    logger = console
+  }) {
+    if (!prisma) {
+      throw new Error('Prisma client instance is required.');
+    }
+
+    this.prisma = prisma;
+    this.commandRunner = commandRunner ?? createDefaultRunner(logger);
+    this.pollIntervalMs = pollIntervalMs;
+    this.logger = logger;
+    this.timer = null;
+  }
+
+  async start() {
+    if (this.timer) {
+      return;
+    }
+
+    await this.collectTelemetry().catch((error) => {
+      this.logger.error?.('Initial telemetry collection failed:', error);
+    });
+
+    this.timer = createInterval(async () => {
+      try {
+        await this.collectTelemetry();
+      } catch (error) {
+        this.logger.error?.('Telemetry polling failed:', error);
+      }
+    }, this.pollIntervalMs);
+  }
+
+  stop() {
+    if (!this.timer) {
+      return;
+    }
+
+    clearTimer(this.timer);
+    this.timer = null;
+  }
+
+  async collectTelemetry() {
+    const apps = await this.prisma.app.findMany({
+      include: {
+        containerStates: true,
+        settings: true
+      }
+    });
+
+    if (apps.length === 0) {
+      return [];
+    }
+
+    let psOutput;
+
+    try {
+      ({ stdout: psOutput } = await this.commandRunner('docker', [
+        'ps',
+        '--all',
+        '--format',
+        '{{json .}}'
+      ]));
+    } catch (error) {
+      this.logger.error?.('docker ps failed, skipping telemetry update.', error);
+      return [];
+    }
+
+    const statsMap = await this.collectStats();
+    const psEntries = parseJsonLines(psOutput);
+    const containersByName = new Map(psEntries.map((entry) => [entry.Names, entry]));
+    const results = [];
+
+    for (const app of apps) {
+      const containerName = resolveContainerName(app);
+      const psSummary = containersByName.get(containerName) ?? null;
+      const existingState = Array.isArray(app.containerStates)
+        ? app.containerStates.find((state) => state.appId === app.id)
+        : null;
+
+      if (!psSummary) {
+        const missingRecord = {
+          containerId: existingState?.containerId ?? containerName,
+          containerName,
+          status: 'MISSING',
+          health: null,
+          state: null,
+          metrics: null,
+          lastObservedAt: new Date()
+        };
+
+        await this.prisma.dockerContainerState.upsert({
+          where: { appId: app.id },
+          update: missingRecord,
+          create: {
+            appId: app.id,
+            ...missingRecord
+          }
+        });
+
+        await this.prisma.app.update({
+          where: { id: app.id },
+          data: {
+            status: 'FAILED'
+          }
+        });
+
+        results.push({ appId: app.id, containerName, status: 'MISSING', metrics: null, state: null });
+        continue;
+      }
+
+      let inspectData = null;
+
+      try {
+        inspectData = await inspectContainer(this.commandRunner, psSummary.ID);
+      } catch (error) {
+        this.logger.error?.(`docker inspect failed for ${containerName}`, error);
+      }
+
+      const status = resolveStatus(inspectData, psSummary);
+      const health = resolveHealth(inspectData, psSummary);
+      const metrics = sanitizeMetrics(statsMap.get(psSummary.Names));
+      const record = {
+        containerId: inspectData?.Id ?? psSummary.ID,
+        containerName,
+        status,
+        health,
+        state: inspectData?.State ?? null,
+        metrics,
+        lastObservedAt: new Date()
+      };
+
+      await this.prisma.dockerContainerState.upsert({
+        where: { appId: app.id },
+        update: record,
+        create: {
+          appId: app.id,
+          ...record
+        }
+      });
+
+      if (status === 'RUNNING') {
+        await this.prisma.app.update({
+          where: { id: app.id },
+          data: {
+            status: 'RUNNING',
+            lastSeenAt: new Date()
+          }
+        });
+      } else if (status === 'EXITED' || status === 'MISSING') {
+        await this.prisma.app.update({
+          where: { id: app.id },
+          data: {
+            status: status === 'EXITED' ? 'STOPPED' : 'FAILED'
+          }
+        });
+      }
+
+      results.push({
+        appId: app.id,
+        containerName,
+        status,
+        health,
+        metrics,
+        state: inspectData?.State ?? null
+      });
+    }
+
+    return results;
+  }
+
+  async collectStats() {
+    try {
+      const { stdout } = await this.commandRunner('docker', [
+        'stats',
+        '--no-stream',
+        '--format',
+        '{{json .}}'
+      ]);
+      return mapStatsByContainerName(stdout);
+    } catch (error) {
+      this.logger.warn?.('docker stats failed; metrics will be unavailable for this cycle.', error);
+      return new Map();
+    }
+  }
+
+  async updateOpenAppBaseUrl(appId, openAppBaseUrl) {
+    if (!appId) {
+      throw new Error('appId is required.');
+    }
+
+    const sanitized = openAppBaseUrl?.trim() || null;
+
+    await this.prisma.app.update({
+      where: { id: appId },
+      data: { openAppBaseUrl: sanitized }
+    });
+
+    await this.prisma.appSettings.upsert({
+      where: { appId },
+      update: { openAppBaseUrl: sanitized },
+      create: { appId, openAppBaseUrl: sanitized }
+    });
+
+    return this.prisma.app.findUnique({
+      where: { id: appId },
+      select: {
+        id: true,
+        name: true,
+        openAppBaseUrl: true,
+        port: true
+      }
+    });
+  }
+
+  buildOpenAppUrl(app) {
+    if (!app) {
+      return null;
+    }
+
+    const base = app.openAppBaseUrl ?? app.settings?.openAppBaseUrl ?? null;
+
+    if (!base || !app.port) {
+      return base ?? null;
+    }
+
+    const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+    return `${sanitizedBase}:${app.port}`;
+  }
+}
+
+export function createDockerOrchestrator(options) {
+  return new DockerOrchestrator(options);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@ export {
   normalizeName,
   validateRegistrationPayload
 } from './framework/validation.js';
+export { DockerOrchestrator, createDockerOrchestrator } from './framework/dockerOrchestrator.js';

--- a/tests/dockerOrchestrator.test.js
+++ b/tests/dockerOrchestrator.test.js
@@ -1,0 +1,157 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DockerOrchestrator } from '../src/framework/dockerOrchestrator.js';
+import { createPrismaDouble } from './helpers/prismaDouble.js';
+
+function createCommandRunner({ psOutput = '', statsOutput = '', inspectOutputs = [] }) {
+  let inspectIndex = 0;
+  const calls = [];
+
+  const runner = async (cmd, args) => {
+    calls.push({ cmd, args });
+    const subcommand = args[0];
+
+    if (subcommand === 'ps') {
+      return { stdout: psOutput, stderr: '' };
+    }
+
+    if (subcommand === 'stats') {
+      return { stdout: statsOutput, stderr: '' };
+    }
+
+    if (subcommand === 'inspect') {
+      const result = inspectOutputs[inspectIndex++];
+      if (!result) {
+        throw new Error('Unexpected docker inspect call.');
+      }
+      return { stdout: result, stderr: '' };
+    }
+
+    throw new Error(`Unsupported docker command: docker ${args.join(' ')}`);
+  };
+
+  return { runner, calls };
+}
+
+test('collectTelemetry persists container state and metrics', async () => {
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-1',
+        name: 'Demo',
+        workspaceSlug: 'demo',
+        port: 8080,
+        status: 'STOPPED'
+      }
+    ]
+  });
+
+  const { runner } = createCommandRunner({
+    psOutput: `${JSON.stringify({
+      ID: 'abcdef',
+      Names: 'dcc-demo',
+      State: 'running',
+      Status: 'Up 5 minutes'
+    })}\n`,
+    statsOutput: `${JSON.stringify({
+      Name: 'dcc-demo',
+      CPUPerc: '12.5%',
+      MemUsage: '100MiB / 2GiB',
+      MemPerc: '5.0%',
+      NetIO: '1kB / 2kB',
+      BlockIO: '0B / 0B',
+      PIDs: '5'
+    })}\n`,
+    inspectOutputs: [
+      JSON.stringify([
+        {
+          Id: 'abcdef',
+          Name: 'dcc-demo',
+          State: {
+            Status: 'running',
+            Running: true,
+            Health: { Status: 'healthy' }
+          }
+        }
+      ])
+    ]
+  });
+
+  const orchestrator = new DockerOrchestrator({ prisma, commandRunner: runner, pollIntervalMs: 50, logger: { warn() {}, error() {}, debug() {} } });
+
+  const results = await orchestrator.collectTelemetry();
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].status, 'RUNNING');
+  assert.equal(results[0].health, 'HEALTHY');
+  assert.equal(results[0].metrics.cpuPercent, 12.5);
+
+  const stateRecord = prisma.state.containerStates.find((entry) => entry.appId === 'app-1');
+  assert.ok(stateRecord, 'container state should be stored');
+  assert.equal(stateRecord.status, 'RUNNING');
+  assert.equal(stateRecord.health, 'HEALTHY');
+  assert.equal(stateRecord.metrics.cpuPercent, 12.5);
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-1');
+  assert.equal(appRecord.status, 'RUNNING');
+  assert.ok(appRecord.lastSeenAt instanceof Date);
+});
+
+test('collectTelemetry marks missing containers as failed', async () => {
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-2',
+        name: 'Missing',
+        workspaceSlug: 'missing',
+        status: 'RUNNING'
+      }
+    ]
+  });
+
+  const { runner } = createCommandRunner({ psOutput: '\n', statsOutput: '\n', inspectOutputs: [] });
+
+  const orchestrator = new DockerOrchestrator({ prisma, commandRunner: runner, logger: { warn() {}, error() {}, debug() {} } });
+
+  const results = await orchestrator.collectTelemetry();
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].status, 'MISSING');
+
+  const stateRecord = prisma.state.containerStates.find((entry) => entry.appId === 'app-2');
+  assert.ok(stateRecord);
+  assert.equal(stateRecord.status, 'MISSING');
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-2');
+  assert.equal(appRecord.status, 'FAILED');
+});
+
+test('updateOpenAppBaseUrl persists settings and buildOpenAppUrl composes links', async () => {
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-3',
+        name: 'Linker',
+        workspaceSlug: 'linker',
+        port: 7000,
+        status: 'STOPPED'
+      }
+    ]
+  });
+
+  const orchestrator = new DockerOrchestrator({ prisma, commandRunner: async () => ({ stdout: '', stderr: '' }), logger: { warn() {}, error() {}, debug() {} } });
+
+  const updated = await orchestrator.updateOpenAppBaseUrl('app-3', 'http://10.0.0.5');
+
+  assert.equal(updated.openAppBaseUrl, 'http://10.0.0.5');
+
+  const settingsRecord = prisma.state.appSettings.find((entry) => entry.appId === 'app-3');
+  assert.ok(settingsRecord);
+  assert.equal(settingsRecord.openAppBaseUrl, 'http://10.0.0.5');
+
+  const appWithSettings = prisma.state.apps.find((entry) => entry.id === 'app-3');
+  assert.equal(appWithSettings.openAppBaseUrl, 'http://10.0.0.5');
+
+  const link = orchestrator.buildOpenAppUrl({ ...appWithSettings, port: 7000 });
+  assert.equal(link, 'http://10.0.0.5:7000');
+});

--- a/tests/helpers/prismaDouble.js
+++ b/tests/helpers/prismaDouble.js
@@ -1,0 +1,182 @@
+export function createPrismaDouble({ apps = [], templates = [], containerStates = [], appSettings = [] } = {}) {
+  const state = {
+    apps: apps.map((app) => ({ ...app })),
+    templates: templates.map((template) => ({ ...template })),
+    containerStates: containerStates.map((entry) => ({ ...entry })),
+    appSettings: appSettings.map((entry) => ({ ...entry }))
+  };
+
+  function cloneApp(app, include) {
+    if (!app) {
+      return null;
+    }
+
+    const copy = { ...app };
+
+    if (include?.containerStates) {
+      copy.containerStates = state.containerStates
+        .filter((entry) => entry.appId === app.id)
+        .map((entry) => ({ ...entry }));
+    }
+
+    if (include?.settings) {
+      copy.settings = state.appSettings.find((entry) => entry.appId === app.id) ?? null;
+      if (copy.settings) {
+        copy.settings = { ...copy.settings };
+      }
+    }
+
+    return copy;
+  }
+
+  const appModel = {
+    async findUnique({ where, select, include } = {}) {
+      const entries = Object.entries(where ?? {});
+
+      if (entries.length === 0) {
+        return null;
+      }
+
+      const [key, value] = entries[0];
+      const record = state.apps.find((app) => app[key] === value);
+
+      if (!record) {
+        return null;
+      }
+
+      if (select) {
+        const selected = {};
+        for (const [field, enabled] of Object.entries(select)) {
+          if (enabled) {
+            selected[field] = record[field];
+          }
+        }
+        return selected;
+      }
+
+      return cloneApp(record, include);
+    },
+
+    async findMany({ include } = {}) {
+      return state.apps.map((app) => cloneApp(app, include));
+    },
+
+    async create({ data }) {
+      const record = {
+        id: data.id ?? `app_${state.apps.length + 1}`,
+        createdAt: data.createdAt ?? new Date(),
+        updatedAt: data.updatedAt ?? new Date(),
+        status: data.status ?? 'STOPPED',
+        lastSeenAt: data.lastSeenAt ?? null,
+        openAppBaseUrl: data.openAppBaseUrl ?? null,
+        ...data
+      };
+      state.apps.push(record);
+      return { ...record };
+    },
+
+    async update({ where, data }) {
+      const index = state.apps.findIndex((app) => app.id === where.id);
+
+      if (index === -1) {
+        throw new Error(`App with id ${where.id} not found.`);
+      }
+
+      const updated = {
+        ...state.apps[index],
+        ...data,
+        updatedAt: data.updatedAt ?? new Date()
+      };
+      state.apps[index] = updated;
+      return { ...updated };
+    }
+  };
+
+  const marketplaceTemplateModel = {
+    async findUnique({ where }) {
+      if (where.id) {
+        return state.templates.find((template) => template.id === where.id) ?? null;
+      }
+
+      if (where.name) {
+        return state.templates.find((template) => template.name === where.name) ?? null;
+      }
+
+      return null;
+    }
+  };
+
+  const appSettingsModel = {
+    async upsert({ where, update, create }) {
+      const index = state.appSettings.findIndex((entry) => entry.appId === where.appId);
+
+      if (index === -1) {
+        const record = {
+          id: create.id ?? `settings_${state.appSettings.length + 1}`,
+          createdAt: create.createdAt ?? new Date(),
+          updatedAt: create.updatedAt ?? new Date(),
+          ...create
+        };
+        state.appSettings.push(record);
+        return { ...record };
+      }
+
+      const updated = {
+        ...state.appSettings[index],
+        ...update,
+        updatedAt: update.updatedAt ?? new Date()
+      };
+      state.appSettings[index] = updated;
+      return { ...updated };
+    }
+  };
+
+  const dockerContainerStateModel = {
+    async upsert({ where, update, create }) {
+      const index = state.containerStates.findIndex((entry) => entry.appId === where.appId);
+
+      if (index === -1) {
+        const record = {
+          id: create.id ?? `state_${state.containerStates.length + 1}`,
+          createdAt: create.createdAt ?? new Date(),
+          updatedAt: create.updatedAt ?? new Date(),
+          ...create
+        };
+        state.containerStates.push(record);
+        return { ...record };
+      }
+
+      const updated = {
+        ...state.containerStates[index],
+        ...update,
+        updatedAt: update.updatedAt ?? new Date()
+      };
+      state.containerStates[index] = updated;
+      return { ...updated };
+    },
+
+    async update({ where, data }) {
+      const index = state.containerStates.findIndex((entry) => entry.appId === where.appId);
+
+      if (index === -1) {
+        throw new Error(`Container state for app ${where.appId} not found.`);
+      }
+
+      const updated = {
+        ...state.containerStates[index],
+        ...data,
+        updatedAt: data.updatedAt ?? new Date()
+      };
+      state.containerStates[index] = updated;
+      return { ...updated };
+    }
+  };
+
+  return {
+    state,
+    app: appModel,
+    marketplaceTemplate: marketplaceTemplateModel,
+    appSettings: appSettingsModel,
+    dockerContainerState: dockerContainerStateModel
+  };
+}


### PR DESCRIPTION
## Why
- align the control center with the requirement that marketplace data, Docker state, and Open App hosts live in the database
- expose telemetry needed by the web UI without relying on environment configuration files

## What
- add a DockerOrchestrator service that polls Docker CLI commands, stores telemetry in Prisma, and manages Open App base URLs
- extend the Prisma schema/migrations with AppSettings, DockerContainerState, and an App-level openAppBaseUrl field plus update seeds
- refresh tests, documentation, and exports to cover the orchestrator workflow and database-backed settings

## Impact
- operators must apply the new Prisma migration before running the orchestrator
- dashboard telemetry now reads from persisted records instead of environment variables

## Testing
- `npm test`

## Docs
- README.md, docs/architecture-overview.md, docs/configuration.md

## Changelog
```
## [2025-10-04 19:30] Add Docker orchestrator telemetry and settings persistence
**Change Type:** Normal Change  
**Why:** Provide database-backed container telemetry and configurable Open App URLs without relying on environment files.  
**What changed:** Introduced a `DockerOrchestrator` service with tests, expanded the Prisma schema (AppSettings, DockerContainerState, openAppBaseUrl), added migrations/seeds, and updated docs plus README to describe telemetry, marketplace persistence, and the mini settings tab.  
**Impact:** Requires running the new Prisma migration; telemetry and custom host links now persist in the database.  
**Testing:** `npm test`  
**Docs:** README.md, docs/architecture-overview.md, docs/configuration.md updated.  
**Rollback Plan:** Revert the commit and roll back Prisma migration `20251004190000_add_docker_orchestrator`.  
**Refs:** N/A
```

------
https://chatgpt.com/codex/tasks/task_e_68e1133b4e708333b562ce1cd727fd66