### PR TITLE
fix: align prisma schema with sqlite json limits

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -59,11 +59,21 @@
 **Refs:** N/A
 
 ## [2025-10-04 19:30] Add Docker orchestrator telemetry and settings persistence
-**Change Type:** Normal Change  
-**Why:** Provide database-backed container telemetry and configurable Open App URLs without relying on environment files.  
-**What changed:** Introduced a `DockerOrchestrator` service with tests, expanded the Prisma schema (AppSettings, DockerContainerState, openAppBaseUrl), added migrations/seeds, and updated docs plus README to describe telemetry, marketplace persistence, and the mini settings tab.  
-**Impact:** Requires running the new Prisma migration; telemetry and custom host links now persist in the database.  
-**Testing:** `npm test`  
-**Docs:** README.md, docs/architecture-overview.md, docs/configuration.md updated.  
-**Rollback Plan:** Revert the commit and roll back Prisma migration `20251004190000_add_docker_orchestrator`.  
+**Change Type:** Normal Change
+**Why:** Provide database-backed container telemetry and configurable Open App URLs without relying on environment files.
+**What changed:** Introduced a `DockerOrchestrator` service with tests, expanded the Prisma schema (AppSettings, DockerContainerState, openAppBaseUrl), added migrations/seeds, and updated docs plus README to describe telemetry, marketplace persistence, and the mini settings tab.
+**Impact:** Requires running the new Prisma migration; telemetry and custom host links now persist in the database.
+**Testing:** `npm test`
+**Docs:** README.md, docs/architecture-overview.md, docs/configuration.md updated.
+**Rollback Plan:** Revert the commit and roll back Prisma migration `20251004190000_add_docker_orchestrator`.
+**Refs:** N/A
+
+## [2025-10-04 21:10] Fix SQLite schema JSON validation failure
+**Change Type:** Standard Change
+**Why:** Prisma install failed because the SQLite connector does not support `Json` columns in the schema.
+**What changed:** Aligned `DockerContainerState.state` and `metrics` fields with the existing TEXT columns, added serialization helpers, updated tests, and documented the JSON encoding approach.
+**Impact:** No migration required; telemetry payloads continue to persist as JSON strings.
+**Testing:** `npm test`
+**Docs:** README.md updated.
+**Rollback Plan:** Revert this commit.
 **Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ await orchestrator.updateOpenAppBaseUrl(app.id, 'http://edge-gateway');
 ### Database
 
 - Prisma schema lives in `prisma/schema.prisma` and targets SQLite by default.
+- Docker telemetry snapshots (`state`, `metrics`) are stored as JSON-encoded text to keep SQLite compatibility; parse before using them downstream.
 - Seed routine (`prisma/seed.js`) now removes legacy demo entries so you always start from a clean slate before onboarding your own apps.
 - Override the `DATABASE_URL` environment variable to point at production-grade storage. The setup automation falls back to `file:/opt/dcc/data/dcc.sqlite` when none is provided.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,8 +56,8 @@ model DockerContainerState {
   containerName  String
   status         String
   health         String?
-  state          Json?
-  metrics        Json?
+  state          String?
+  metrics        String?
   lastObservedAt DateTime @default(now())
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt

--- a/src/framework/dockerOrchestrator.js
+++ b/src/framework/dockerOrchestrator.js
@@ -82,6 +82,20 @@ function sanitizeMetrics(entry) {
   };
 }
 
+function serializeNullableJson(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    const failure = new Error('Failed to serialize telemetry payload.');
+    failure.cause = error;
+    throw failure;
+  }
+}
+
 function createDefaultRunner(logger) {
   return (command, args = [], options = {}) =>
     new Promise((resolve, reject) => {
@@ -248,8 +262,8 @@ export class DockerOrchestrator {
         containerName,
         status,
         health,
-        state: inspectData?.State ?? null,
-        metrics,
+        state: serializeNullableJson(inspectData?.State ?? null),
+        metrics: serializeNullableJson(metrics),
         lastObservedAt: new Date()
       };
 

--- a/tests/dockerOrchestrator.test.js
+++ b/tests/dockerOrchestrator.test.js
@@ -90,7 +90,10 @@ test('collectTelemetry persists container state and metrics', async () => {
   assert.ok(stateRecord, 'container state should be stored');
   assert.equal(stateRecord.status, 'RUNNING');
   assert.equal(stateRecord.health, 'HEALTHY');
-  assert.equal(stateRecord.metrics.cpuPercent, 12.5);
+  const storedMetrics = JSON.parse(stateRecord.metrics);
+  assert.equal(storedMetrics.cpuPercent, 12.5);
+  const storedState = JSON.parse(stateRecord.state);
+  assert.equal(storedState.Status, 'running');
 
   const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-1');
   assert.equal(appRecord.status, 'RUNNING');


### PR DESCRIPTION
## Summary
- Fix the Prisma schema validation failure during setup by aligning `DockerContainerState.state` and `metrics` with SQLite text columns
- Serialize telemetry payloads before persisting them so Prisma accepts the data and existing records remain compatible
- Document the JSON-encoded text storage and keep unit tests validating the serialized state

## Impact
- Restores `npm install` / `npx prisma generate` flow on SQLite-backed environments without requiring a migration

## Testing
- `npm test`

## Docs
- README.md updated

## Changelog
## [2025-10-04 21:10] Fix SQLite schema JSON validation failure
**Change Type:** Standard Change
**Why:** Prisma install failed because the SQLite connector does not support `Json` columns in the schema.
**What changed:** Aligned `DockerContainerState.state` and `metrics` fields with the existing TEXT columns, added serialization helpers, updated tests, and documented the JSON encoding approach.
**Impact:** No migration required; telemetry payloads continue to persist as JSON strings.
**Testing:** `npm test`
**Docs:** README.md updated.
**Rollback Plan:** Revert this commit.
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e116ae419483338eda19dbafeb99ce