### PR TITLE
ui: clarify preview dialogs and remove demo artifacts

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -77,3 +77,13 @@
 **Docs:** README.md updated.
 **Rollback Plan:** Revert this commit.
 **Refs:** N/A
+
+## [2025-10-04 22:30] Remove demo UI artifacts and disable unfinished dialogs
+**Change Type:** Standard Change
+**Why:** Prevent confusion caused by non-functional Add App/Marketplace previews and lingering demo content.
+**What changed:** Cleared placeholder app rows and example marketplace cards from the dashboard build script, disabled Add App and Marketplace form controls until the backend is wired up, refreshed README guidance, and documented the preview status in the architecture overview.
+**Impact:** Dashboard now shows empty states only; operators see disabled controls instead of demo data. No database impact.
+**Testing:** `npm run build`, `npm test`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert commit and rerun `npm run build` to regenerate assets.
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A lightweight control plane for hosting GPU-accelerated AI applications on demand.
 
 ## Features
-- Guided "Add App" dialog prepared for validating metadata and provisioning GPU-ready Docker Compose stacks.
-- Marketplace dialog that surfaces previously installed apps as reusable templates stored in Prisma + SQLite.
+- Preview-only "Add App" dialog ready for backend validation and provisioning once the API is connected (controls currently disabled).
+- Marketplace dialog that will surface previously installed apps as reusable templates stored in Prisma + SQLite once populated (currently shows the empty state only).
 - Telemetry orchestrator that normalizes Docker runtime state, stores it in Prisma (`DockerContainerState`), and keeps marketplace entries plus container health entirely in the database.
 - Application fleet table with open-app quick links, start/stop/reinstall/deinstall controls, and traffic-light health signals (red/offline, yellow/installing, green/online/port reachable).
 - Mini settings tab persisted via `AppSettings` so operators can store custom Open App base URLs (e.g., `http://my-host`) without editing environment files.
@@ -47,9 +47,11 @@ rollback flow that removes files and Docker packages it introduced. Configure th
 > Document additional environment variables in `/docs/configuration.md` as they are introduced.
 
 ## Usage
-1. Open the dashboard and choose **Add App** to launch the registration dialog.
-2. Provide the application name, Git repository URL, container start command, and service port. Attach or reuse a marketplace template to speed up provisioning.
-3. Submit the form to trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
+> **Note:** The current dashboard build ships as a static preview. The Add App and Marketplace dialogs are disabled until the backend API is wired up.
+
+1. Open the dashboard and review the **Add App** preview to plan the metadata required for onboarding.
+2. Ensure your Git repository and start command are ready for when the backend integration lands.
+3. Once the API is available, submitting the form will trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
 4. Monitor build progress and container readiness directly in the dashboard. Status lamps turn green once the configured port responds.
 5. Promote successful installs into the marketplace dialog for future reuse.
 
@@ -63,8 +65,8 @@ import { AppLifecycleManager } from 'docker-control-center';
 const manager = new AppLifecycleManager({ prisma });
 
 const app = await manager.registerApp({
-  name: 'My Stable Diffusion',
-  repositoryUrl: 'https://github.com/example/stable-diffusion.git',
+  name: 'My GPU App',
+  repositoryUrl: 'https://github.com/example/gpu-app.git',
   startCommand: 'python launch.py --listen',
   port: 7860
 });

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -15,6 +15,7 @@
      - `port`: HTTP port exposed by the application and probed for reachability.
      - `template`: optional reference to a `MarketplaceTemplate` entry for pre-populated defaults.
    - Validation ensures name uniqueness, required fields, and marketplace template integrity via Prisma.
+   - The placeholder dashboard keeps the controls disabled until the backend API is connected, preventing the old demo workflow from appearing functional.
 
 2. **Workspace Provisioning**
    - Clone the Git repository into `/opt/dockerstore/<name>`.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -122,6 +122,23 @@ function writePlaceholderAssets() {
         box-shadow: 0 12px 30px rgba(56, 139, 253, 0.25);
       }
 
+      fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+        min-inline-size: auto;
+      }
+
+      fieldset[disabled] {
+        opacity: 0.6;
+      }
+
+      .dialog__note {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
       .layout-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -497,28 +514,6 @@ function writePlaceholderAssets() {
                 </div>
               </td>
             </tr>
-            <tr>
-              <td>
-                <strong>Example GPU Inference</strong>
-                <div class="table-hint">This preview row illustrates the controls available once an app is running.</div>
-              </td>
-              <td>
-                <span class="status-pill" data-status="RUNNING">
-                  <span class="status-dot"></span>
-                  Running
-                </span>
-              </td>
-              <td>7860</td>
-              <td>Online • port reachable</td>
-              <td>
-                <div class="table-actions">
-                  <button class="primary">Open App</button>
-                  <button>Stop</button>
-                  <button>Restart</button>
-                  <button>Deinstall</button>
-                </div>
-              </td>
-            </tr>
           </tbody>
         </table>
         <p class="table-hint">Green = port reachable, Yellow = probing/compose deploy, Red = offline.</p>
@@ -534,11 +529,12 @@ function writePlaceholderAssets() {
         <div class="dialog__header">
           <div>
             <h2>Register Application</h2>
-            <p class="table-hint">Validated against Prisma before Docker Compose provisioning kicks off.</p>
+            <p class="table-hint">Preview only until the backend API is connected.</p>
           </div>
           <button value="cancel" class="secondary">Close</button>
         </div>
-        <div class="form-grid">
+        <p class="dialog__note">Form controls are disabled while Add App integration is in progress.</p>
+        <fieldset class="form-grid" disabled>
           <label>
             App Name
             <input name="name" placeholder="e.g. Stable Diffusion" required />
@@ -559,13 +555,13 @@ function writePlaceholderAssets() {
             Marketplace Template
             <select name="template">
               <option value="">Create new template</option>
-              <option value="" disabled>No saved templates yet</option>
+              <option value="" disabled>Templates appear once installs are promoted</option>
             </select>
           </label>
-        </div>
+        </fieldset>
         <div class="dialog__footer">
           <button class="secondary" value="cancel">Cancel</button>
-          <button type="submit">Schedule Install</button>
+          <button type="submit" disabled title="Add App will be enabled once the API is wired up.">Schedule Install</button>
         </div>
       </form>
     </dialog>
@@ -575,10 +571,11 @@ function writePlaceholderAssets() {
         <div class="dialog__header">
           <div>
             <h2>App Marketplace</h2>
-            <p class="table-hint">Entries originate from completed installs stored in SQLite for reuse.</p>
+            <p class="table-hint">Entries will appear after successful installs are promoted.</p>
           </div>
           <button value="cancel" class="secondary">Close</button>
         </div>
+        <p class="dialog__note">No marketplace templates exist yet. Promote an app from the dashboard once the backend ships.</p>
         <div class="marketplace-grid">
           <div class="marketplace-card">
             <div class="tag-list">
@@ -588,18 +585,10 @@ function writePlaceholderAssets() {
             <p class="table-hint">Templates appear after promoting a successfully installed app.</p>
             <button type="submit" disabled>Deploy Template</button>
           </div>
-          <div class="marketplace-card">
-            <div class="tag-list">
-              <span>Preview</span>
-            </div>
-            <h3>Example Template</h3>
-            <p class="table-hint">Once templates exist, operators can launch new installs in one click.</p>
-            <button type="submit">Deploy Template</button>
-          </div>
         </div>
         <div class="dialog__footer">
           <button class="secondary" value="cancel">Close</button>
-          <button type="submit">Add Selected</button>
+          <button type="submit" disabled title="Marketplace actions will activate with the backend.">Add Selected</button>
         </div>
       </form>
     </dialog>


### PR DESCRIPTION
## Why
- Add App and marketplace dialogs appeared functional even though no backend API exists yet
- Demo rows and template cards confused operators expecting real data

## What
- Disable Add App and marketplace dialog controls and add preview messaging in the dashboard build script
- Remove placeholder fleet and marketplace entries so only true empty states are shown
- Refresh README usage guidance and architecture overview with the preview/disabled status

## Impact
- Dashboard visitors now see disabled controls and no demo data, reducing confusion while waiting for backend wiring

## Testing
- `npm run build`
- `npm test`

## Docs
- README.md
- docs/architecture-overview.md

### Changelog
## [2025-10-04 22:30] Remove demo UI artifacts and disable unfinished dialogs
**Change Type:** Standard Change
**Why:** Prevent confusion caused by non-functional Add App/Marketplace previews and lingering demo content.
**What changed:** Cleared placeholder app rows and example marketplace cards from the dashboard build script, disabled Add App and Marketplace form controls until the backend is wired up, refreshed README guidance, and documented the preview status in the architecture overview.
**Impact:** Dashboard now shows empty states only; operators see disabled controls instead of demo data. No database impact.
**Testing:** `npm run build`, `npm test`
**Docs:** README.md, docs/architecture-overview.md updated.
**Rollback Plan:** Revert commit and rerun `npm run build` to regenerate assets.
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e11b15c76083338ca41650381cec38