### PR TITLE
ui: enable local marketplace workflow

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -87,3 +87,13 @@
 **Docs:** README.md, docs/architecture-overview.md updated.
 **Rollback Plan:** Revert commit and rerun `npm run build` to regenerate assets.
 **Refs:** N/A
+
+## [2025-10-05 09:00] Enable local marketplace authoring
+**Change Type:** Normal Change
+**Why:** Provide an interactive Add App workflow while the backend API is finalized.
+**What changed:** Activated the Add App form, persisted templates to browser storage, added edit/terminate marketplace controls, and refreshed documentation.
+**Impact:** Templates are stored per browser session; backend services remain unchanged.
+**Testing:** `npm run build`, `npm test`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A lightweight control plane for hosting GPU-accelerated AI applications on demand.
 
 ## Features
-- Preview-only "Add App" dialog ready for backend validation and provisioning once the API is connected (controls currently disabled).
-- Marketplace dialog that will surface previously installed apps as reusable templates stored in Prisma + SQLite once populated (currently shows the empty state only).
+- Interactive "Add App" dialog that saves onboarding metadata as reusable marketplace templates in the browser until the backend API is connected.
+- Marketplace dialog with local templates that can be edited (blue **E**) or terminated (red **X**) before backend persistence arrives.
 - Telemetry orchestrator that normalizes Docker runtime state, stores it in Prisma (`DockerContainerState`), and keeps marketplace entries plus container health entirely in the database.
 - Application fleet table with open-app quick links, start/stop/reinstall/deinstall controls, and traffic-light health signals (red/offline, yellow/installing, green/online/port reachable).
 - Mini settings tab persisted via `AppSettings` so operators can store custom Open App base URLs (e.g., `http://my-host`) without editing environment files.
@@ -47,10 +47,8 @@ rollback flow that removes files and Docker packages it introduced. Configure th
 > Document additional environment variables in `/docs/configuration.md` as they are introduced.
 
 ## Usage
-> **Note:** The current dashboard build ships as a static preview. The Add App and Marketplace dialogs are disabled until the backend API is wired up.
-
-1. Open the dashboard and review the **Add App** preview to plan the metadata required for onboarding.
-2. Ensure your Git repository and start command are ready for when the backend integration lands.
+1. Open the dashboard and use **Add App** to capture app metadata; entries persist in browser storage and populate the marketplace dialog instantly.
+2. Edit saved templates via the blue **E** action or remove them with the red **X** while waiting for the backend rollout.
 3. Once the API is available, submitting the form will trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
 4. Monitor build progress and container readiness directly in the dashboard. Status lamps turn green once the configured port responds.
 5. Promote successful installs into the marketplace dialog for future reuse.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -15,7 +15,7 @@
      - `port`: HTTP port exposed by the application and probed for reachability.
      - `template`: optional reference to a `MarketplaceTemplate` entry for pre-populated defaults.
    - Validation ensures name uniqueness, required fields, and marketplace template integrity via Prisma.
-   - The placeholder dashboard keeps the controls disabled until the backend API is connected, preventing the old demo workflow from appearing functional.
+   - The static dashboard build stores submitted templates in browser storage while the backend API is finalized, allowing operators to refine metadata without touching the database.
 
 2. **Workspace Provisioning**
    - Clone the Git repository into `/opt/dockerstore/<name>`.
@@ -37,7 +37,7 @@
 
 5. **Marketplace Reuse**
    - Completed installs can promote their metadata into `MarketplaceTemplate` records.
-   - The marketplace dialog lists templates created from successful installs without bundling demo data by default.
+   - The marketplace dialog lists locally captured templates immediately and will transition to Prisma-backed data once lifecycle promotion is wired up.
    - Templates store summaries, repository URLs, default ports, GPU requirements, and refer back to the originating app when available.
 
 ## Component Responsibilities


### PR DESCRIPTION
## Why
- Deliver a functional Add App flow that operators can try while the backend API is still in flight.

## What
- Activate the Add App form, persist marketplace templates in browser storage, and surface edit (blue E) plus terminate (red X) actions per entry.
- Refresh the marketplace dialog rendering, add styling for the new controls, and wire edit/delete handlers.
- Update README and architecture overview to describe the interim local-storage workflow.

## Impact
- Templates are stored per browser; no backend data changes occur until the API ships.

## Testing
- npm run build
- npm test

## Docs
- README.md
- docs/architecture-overview.md

## Changelog
## [2025-10-05 09:00] Enable local marketplace authoring
**Change Type:** Normal Change
**Why:** Provide an interactive Add App workflow while the backend API is finalized.
**What changed:** Activated the Add App form, persisted templates to browser storage, added edit/terminate marketplace controls, and refreshed documentation.
**Impact:** Templates are stored per browser session; backend services remain unchanged.
**Testing:** `npm run build`, `npm test`
**Docs:** README.md, docs/architecture-overview.md updated.
**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e12a1f9ff4833397bfeeba8d37d973