### PR TITLE
ui: add lifecycle controls to fleet preview

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -99,11 +99,21 @@
 **Refs:** N/A
 
 ## [2025-10-05 12:00] Allow marketplace templates to deploy in the preview UI
-**Change Type:** Normal Change  
-**Why:** Operators could capture templates but not simulate installing them from the marketplace dialog.  
-**What changed:** Added a Deploy control that installs templates into a local fleet list, updated stats, and refreshed docs to describe the new preview behavior.  
-**Impact:** Installations are still local-storage simulations; no backend or database changes required.  
-**Testing:** `npm run build`, `npm test`  
-**Docs:** README.md, docs/architecture-overview.md updated.  
-**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.  
+**Change Type:** Normal Change
+**Why:** Operators could capture templates but not simulate installing them from the marketplace dialog.
+**What changed:** Added a Deploy control that installs templates into a local fleet list, updated stats, and refreshed docs to describe the new preview behavior.
+**Impact:** Installations are still local-storage simulations; no backend or database changes required.
+**Testing:** `npm run build`, `npm test`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
+**Refs:** N/A
+
+## [2025-10-05 15:30] Add lifecycle controls to the fleet table preview
+**Change Type:** Normal Change
+**Why:** Provide operators with simulated start/stop and maintenance actions while the backend API is under development.
+**What changed:** Replaced the fleet placeholder message with Start/Stop, Reinstall, and Deinstall buttons that update local app records and disable during installs; refreshed README guidance.
+**Impact:** Frontend-only simulation updates; no backend or database changes required.
+**Testing:** `npm run build`, `npm test`
+**Docs:** README.md updated.
+**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
 **Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ rollback flow that removes files and Docker packages it introduced. Configure th
 1. Open the dashboard and use **Add App** to capture app metadata; entries persist in browser storage and populate the marketplace dialog instantly.
 2. Launch saved templates with the green **Deploy** action, edit them via the blue **E**, or remove them with the red **X**. Deployed templates now populate the fleet table to simulate an install until the backend arrives.
 3. Once the API is available, submitting the form will trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
-4. Monitor build progress and container readiness directly in the dashboard. Status lamps turn green once the configured port responds.
+4. Monitor build progress and container readiness directly in the dashboard. Use the Start/Stop toggle, Reinstall, and Deinstall actions in the fleet table to simulate lifecycle operations while status lamps track progress (green = reachable).
 5. Promote successful installs into the marketplace dialog for future reuse.
 
 ### Programmatic API


### PR DESCRIPTION
## Why
- Provide operators with interactive lifecycle actions while the backend API is under construction.

## What
- Replace the fleet table placeholder with Start/Stop, Reinstall, and Deinstall buttons that mutate stored app records.
- Disable lifecycle controls while installs are in progress and toggle Start/Stop labels based on status.
- Refresh README guidance to highlight the new fleet actions and document the simulation behavior.

## Impact
- Frontend-only simulation updates; no backend or database changes required.

## Testing
- `npm test`
- `npm run build`

## Docs
- README.md updated.

### Changelog
## [2025-10-05 15:30] Add lifecycle controls to the fleet table preview
**Change Type:** Normal Change
**Why:** Provide operators with simulated start/stop and maintenance actions while the backend API is under development.
**What changed:** Replaced the fleet placeholder message with Start/Stop, Reinstall, and Deinstall buttons that update local app records and disable during installs; refreshed README guidance.
**Impact:** Frontend-only simulation updates; no backend or database changes required.
**Testing:** `npm run build`, `npm test`
**Docs:** README.md updated.
**Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
**Refs:** N/A


------
https://chatgpt.com/codex/tasks/task_e_68e135262b4083338f58ee72c8549d77