### PR TITLE
lifecycle: wire dashboard controls to Docker

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -117,3 +117,13 @@
 **Docs:** README.md updated.
 **Rollback Plan:** Revert the commit and rerun `npm run build` to regenerate assets.
 **Refs:** N/A
+
+## [2025-10-06 09:30] Wire lifecycle controls to Docker runtime
+**Change Type:** Normal Change
+**Why:** Execute dashboard lifecycle actions against real containers instead of frontend-only simulations.
+**What changed:** Extended `AppLifecycleManager` with start/stop/restart/reinstall/deinstall helpers, updated Prisma doubles and unit tests, and refreshed documentation to describe the Docker-backed workflow.
+**Impact:** Lifecycle commands now call the Docker CLI; ensure the host has Docker installed and accessible to the service account.
+**Testing:** `npm test`
+**Docs:** README.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert this commit.
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ rollback flow that removes files and Docker packages it introduced. Configure th
 1. Open the dashboard and use **Add App** to capture app metadata; entries persist in browser storage and populate the marketplace dialog instantly.
 2. Launch saved templates with the green **Deploy** action, edit them via the blue **E**, or remove them with the red **X**. Deployed templates now populate the fleet table to simulate an install until the backend arrives.
 3. Once the API is available, submitting the form will trigger repository cloning into `/opt/dockerstore/<appname>` and Compose generation.
-4. Monitor build progress and container readiness directly in the dashboard. Use the Start/Stop toggle, Reinstall, and Deinstall actions in the fleet table to simulate lifecycle operations while status lamps track progress (green = reachable).
+4. Monitor build progress and container readiness directly in the dashboard. Lifecycle controls (Start, Stop, Restart, Reinstall, Deinstall) now invoke the backend `AppLifecycleManager`, which shells out to Docker to operate on each app's Compose stack while status lamps track progress (green = reachable).
 5. Promote successful installs into the marketplace dialog for future reuse.
 
 ### Programmatic API
@@ -70,6 +70,13 @@ const app = await manager.registerApp({
 });
 
 await manager.installApp(app.id);
+
+// Manage the stack in response to dashboard actions
+await manager.startApp(app.id);
+await manager.restartApp(app.id);
+await manager.stopApp(app.id);
+await manager.reinstallApp(app.id);
+await manager.deinstallApp(app.id);
 ```
 
 The manager enforces validation rules, derives a sanitized `workspaceSlug`, writes a GPU-ready Compose file under `/opt/dockerstore/<slug>/docker-compose.yaml`, and executes `docker compose up -d` to provision the service.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -46,7 +46,7 @@
 | --- | --- |
 | Web Frontend | Responsive UI for onboarding dialogs, marketplace browsing, status table, and lifecycle actions. Employs real-time updates without constant refreshes. |
 | API / Backend | Validates submissions, manages Git interactions, renders Compose templates, orchestrates lifecycle actions, and surfaces health probes. |
-| Lifecycle Manager | Node.js service (`AppLifecycleManager`) that validates inputs, derives workspace slugs, syncs Git repositories, writes Compose manifests, and executes `docker compose up -d` while updating Prisma status fields. |
+| Lifecycle Manager | Node.js service (`AppLifecycleManager`) that validates inputs, derives workspace slugs, syncs Git repositories, writes Compose manifests, executes `docker compose up -d`, and now provides start/stop/restart/reinstall/deinstall helpers that wrap Docker CLI commands while updating Prisma status fields. |
 | Telemetry Orchestrator | Background service (`DockerOrchestrator`) that polls Docker, stores normalized telemetry in `DockerContainerState`, and hydrates dashboard-ready payloads including "Open App" URLs from `AppSettings`. |
 | Worker / Runner | Executes repository cloning, dependency installation, compose orchestration, and port health checks with GPU support. |
 | Storage Layer | Hosts `/opt/dockerstore` directories and durable metadata (Prisma-managed SQLite by default). Stores both active apps and marketplace templates. |

--- a/tests/appLifecycleManager.test.js
+++ b/tests/appLifecycleManager.test.js
@@ -109,3 +109,272 @@ test('installApp writes compose file and triggers docker compose', async (t) => 
   assert.equal(updatedApp.status, 'RUNNING');
   assert.ok(updatedApp.lastSeenAt instanceof Date);
 });
+
+test('startApp uses existing compose manifest to boot the stack', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-start-'));
+  t.after(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const workspaceSlug = 'start-demo';
+  const workspacePath = path.join(tempRoot, workspaceSlug);
+  const composePath = path.join(workspacePath, 'docker-compose.yaml');
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(composePath, "version: '3.9'\nservices:\n  app:\n    image: demo\n", 'utf8');
+
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-start',
+        name: 'Start Demo',
+        workspaceSlug,
+        status: 'STOPPED'
+      }
+    ]
+  });
+
+  const commands = [];
+  const manager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot: tempRoot,
+    commandRunner: async (cmd, args, options) => {
+      commands.push({ cmd, args, options });
+      return { stdout: '', stderr: '' };
+    },
+    logger: { warn() {}, error() {}, debug() {} }
+  });
+
+  const result = await manager.startApp('app-start');
+
+  assert.equal(commands.length, 1);
+  assert.deepEqual(commands[0].args, ['compose', '-f', composePath, 'up', '-d']);
+  assert.equal(commands[0].options.cwd, workspacePath);
+  assert.equal(commands[0].options.env.COMPOSE_PROJECT_NAME, 'dcc-start-demo');
+  assert.equal(result.composePath, composePath);
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-start');
+  assert.equal(appRecord.status, 'RUNNING');
+  assert.ok(appRecord.lastSeenAt instanceof Date);
+});
+
+test('stopApp tears down docker compose and updates telemetry', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-stop-'));
+  t.after(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const workspaceSlug = 'stop-demo';
+  const workspacePath = path.join(tempRoot, workspaceSlug);
+  const composePath = path.join(workspacePath, 'docker-compose.yaml');
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(composePath, "version: '3.9'\nservices:\n  app:\n    image: demo\n", 'utf8');
+
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-stop',
+        name: 'Stop Demo',
+        workspaceSlug,
+        status: 'RUNNING'
+      }
+    ],
+    containerStates: [
+      {
+        id: 'state-1',
+        appId: 'app-stop',
+        containerId: 'container-123',
+        containerName: 'dcc-stop-demo',
+        status: 'RUNNING',
+        metrics: null,
+        state: null,
+        lastObservedAt: new Date()
+      }
+    ]
+  });
+
+  const commands = [];
+  const manager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot: tempRoot,
+    commandRunner: async (cmd, args, options) => {
+      commands.push({ cmd, args, options });
+      return { stdout: '', stderr: '' };
+    },
+    logger: { warn() {}, error() {}, debug() {} }
+  });
+
+  const result = await manager.stopApp('app-stop');
+
+  assert.equal(commands.length, 1);
+  assert.deepEqual(commands[0].args, ['compose', '-f', composePath, 'down', '--remove-orphans']);
+  assert.equal(commands[0].options.cwd, workspacePath);
+  assert.equal(commands[0].options.env.COMPOSE_PROJECT_NAME, 'dcc-stop-demo');
+  assert.equal(result.composePath, composePath);
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-stop');
+  assert.equal(appRecord.status, 'STOPPED');
+  assert.equal(appRecord.lastSeenAt, null);
+
+  const stateRecord = prisma.state.containerStates.find((entry) => entry.appId === 'app-stop');
+  assert.equal(stateRecord.status, 'STOPPED');
+  assert.equal(stateRecord.containerId, 'container-123');
+  assert.equal(stateRecord.metrics, null);
+});
+
+test('restartApp restarts containers using docker compose', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-restart-'));
+  t.after(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const workspaceSlug = 'restart-demo';
+  const workspacePath = path.join(tempRoot, workspaceSlug);
+  const composePath = path.join(workspacePath, 'docker-compose.yaml');
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(composePath, "version: '3.9'\nservices:\n  app:\n    image: demo\n", 'utf8');
+
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-restart',
+        name: 'Restart Demo',
+        workspaceSlug,
+        status: 'RUNNING'
+      }
+    ]
+  });
+
+  const commands = [];
+  const manager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot: tempRoot,
+    commandRunner: async (cmd, args, options) => {
+      commands.push({ cmd, args, options });
+      return { stdout: '', stderr: '' };
+    },
+    logger: { warn() {}, error() {}, debug() {} }
+  });
+
+  await manager.restartApp('app-restart');
+
+  assert.equal(commands.length, 1);
+  assert.deepEqual(commands[0].args, ['compose', '-f', composePath, 'restart']);
+  assert.equal(commands[0].options.env.COMPOSE_PROJECT_NAME, 'dcc-restart-demo');
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-restart');
+  assert.equal(appRecord.status, 'RUNNING');
+  assert.ok(appRecord.lastSeenAt instanceof Date);
+});
+
+test('reinstallApp stops the stack before reinstalling', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-reinstall-'));
+  t.after(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const workspaceSlug = 'reinstall-demo';
+  const workspacePath = path.join(tempRoot, workspaceSlug);
+  const composePath = path.join(workspacePath, 'docker-compose.yaml');
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(composePath, "version: '3.9'\nservices:\n  app:\n    image: demo\n", 'utf8');
+
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-reinstall',
+        name: 'Reinstall Demo',
+        workspaceSlug,
+        repositoryUrl: null,
+        status: 'RUNNING'
+      }
+    ]
+  });
+
+  const commands = [];
+  const manager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot: tempRoot,
+    commandRunner: async (cmd, args, options) => {
+      commands.push({ cmd, args, options });
+      return { stdout: '', stderr: '' };
+    },
+    logger: { warn() {}, error() {}, debug() {} }
+  });
+
+  await manager.reinstallApp('app-reinstall', { skipClone: true });
+
+  assert.equal(commands.length, 2);
+  assert.deepEqual(commands[0].args, ['compose', '-f', composePath, 'down', '--remove-orphans']);
+  assert.deepEqual(commands[1].args, ['compose', '-f', composePath, 'up', '-d']);
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-reinstall');
+  assert.equal(appRecord.status, 'RUNNING');
+});
+
+test('deinstallApp removes the workspace and container state', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-deinstall-'));
+  t.after(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const workspaceSlug = 'deinstall-demo';
+  const workspacePath = path.join(tempRoot, workspaceSlug);
+  const composePath = path.join(workspacePath, 'docker-compose.yaml');
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(composePath, "version: '3.9'\nservices:\n  app:\n    image: demo\n", 'utf8');
+
+  const prisma = createPrismaDouble({
+    apps: [
+      {
+        id: 'app-deinstall',
+        name: 'Deinstall Demo',
+        workspaceSlug,
+        status: 'RUNNING'
+      }
+    ],
+    containerStates: [
+      {
+        id: 'state-del',
+        appId: 'app-deinstall',
+        containerId: 'container-del',
+        containerName: 'dcc-deinstall-demo',
+        status: 'RUNNING',
+        metrics: null,
+        state: null,
+        lastObservedAt: new Date()
+      }
+    ]
+  });
+
+  const commands = [];
+  const manager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot: tempRoot,
+    commandRunner: async (cmd, args, options) => {
+      commands.push({ cmd, args, options });
+      return { stdout: '', stderr: '' };
+    },
+    logger: { warn() {}, error() {}, debug() {} }
+  });
+
+  await manager.deinstallApp('app-deinstall');
+
+  assert.equal(commands.length, 1);
+  assert.deepEqual(commands[0].args, [
+    'compose',
+    '-f',
+    composePath,
+    'down',
+    '--remove-orphans',
+    '--volumes'
+  ]);
+
+  await assert.rejects(async () => fs.access(workspacePath));
+
+  const stateRecord = prisma.state.containerStates.find((entry) => entry.appId === 'app-deinstall');
+  assert.equal(stateRecord, undefined);
+
+  const appRecord = prisma.state.apps.find((entry) => entry.id === 'app-deinstall');
+  assert.equal(appRecord.status, 'STOPPED');
+  assert.equal(appRecord.lastSeenAt, null);
+});

--- a/tests/helpers/prismaDouble.js
+++ b/tests/helpers/prismaDouble.js
@@ -169,6 +169,27 @@ export function createPrismaDouble({ apps = [], templates = [], containerStates 
       };
       state.containerStates[index] = updated;
       return { ...updated };
+    },
+
+    async delete({ where }) {
+      const index = state.containerStates.findIndex((entry) => {
+        if (where.appId) {
+          return entry.appId === where.appId;
+        }
+
+        if (where.id) {
+          return entry.id === where.id;
+        }
+
+        return false;
+      });
+
+      if (index === -1) {
+        throw new Error('Container state not found.');
+      }
+
+      const [removed] = state.containerStates.splice(index, 1);
+      return { ...removed };
     }
   };
 


### PR DESCRIPTION
## Why
- Execute dashboard lifecycle actions against actual Docker containers instead of front-end simulations.

## What
- Added Docker-backed start/stop/restart/reinstall/deinstall helpers to `AppLifecycleManager`.
- Expanded the Prisma test double and lifecycle unit tests to cover the new commands.
- Documented the Docker workflow and lifecycle controls in README and architecture docs.

## Impact
- Lifecycle operations now require Docker to be present and accessible to the service account.

## Testing
- `npm test`

## Docs
- README.md
- docs/architecture-overview.md

## Changelog
## [2025-10-06 09:30] Wire lifecycle controls to Docker runtime
**Change Type:** Normal Change
**Why:** Execute dashboard lifecycle actions against real containers instead of frontend-only simulations.
**What changed:** Extended `AppLifecycleManager` with start/stop/restart/reinstall/deinstall helpers, updated Prisma doubles and unit tests, and refreshed documentation to describe the Docker-backed workflow.
**Impact:** Lifecycle commands now call the Docker CLI; ensure the host has Docker installed and accessible to the service account.
**Testing:** `npm test`
**Docs:** README.md, docs/architecture-overview.md updated.
**Rollback Plan:** Revert this commit.
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e136dcc24c8333ba8b836dbd7f2fd1