### PR TITLE
api: launch express backend service

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -127,3 +127,13 @@
 **Docs:** README.md, docs/architecture-overview.md updated.
 **Rollback Plan:** Revert this commit.
 **Refs:** N/A
+
+## [2025-10-06 13:00] Launch Express backend API
+**Change Type:** Normal Change  
+**Why:** Provide a real backend for the dashboard to register, install, and monitor applications.  
+**What changed:** Added an Express-based API server with lifecycle, telemetry, and marketplace routes; introduced configuration helpers, error handling, and REST documentation; updated tests with Supertest coverage.  
+**Impact:** New `npm run api:start` process exposes management endpoints on `DCC_API_PORT`; ensure Docker/Prisma connectivity before enabling auto-telemetry.  
+**Testing:** `npm test`  
+**Docs:** README.md, docs/api.md, docs/architecture-overview.md, docs/configuration.md updated.  
+**Rollback Plan:** Revert the API server commit and remove the new documentation/tests.  
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -23,8 +23,20 @@ npm install
 npx prisma migrate dev --name init
 npx prisma db seed
 npm run build
+
+# Start the backend API (new terminal recommended)
+npm run api:start
+
+# Launch the dashboard preview (separate terminal)
 npm start
 ```
+
+## Backend API
+- Express-based service exposing lifecycle, telemetry, and marketplace endpoints under `http://localhost:${DCC_API_PORT:-4000}`.
+- Returns normalized Prisma records with parsed telemetry metrics and derived `openAppUrl` helpers.
+- Provides lifecycle helpers (`/apps/:id/install|start|stop|restart|reinstall`), settings updates, template CRUD, and `/telemetry/collect` for on-demand Docker polling.
+
+Refer to [`docs/api.md`](docs/api.md) for detailed request/response examples and error semantics.
 
 Need to undo the setup? Execute `node scripts/setup.js --rollback` to restore the previous state. The installer creates `/opt/dcc/app` for the built dashboard, `/opt/dcc/repo` with the full Git clone (ready for `git pull`), `/opt/dcc/data` for runtime files (including `dcc.sqlite`), runs Prisma migrations/seeding automatically, and starts the static dashboard server on `http://localhost:${DCC_DASHBOARD_PORT:-8080}`.
 
@@ -41,6 +53,9 @@ rollback flow that removes files and Docker packages it introduced. Configure th
 | `DCC_STORAGE_ROOT` | `/opt/dockerstore` | Root directory for application checkouts mounted into containers. |
 | `DCC_BASE_IMAGE` | `nvcr.io/nvidia/pytorch:latest` | GPU-enabled base image used in generated Docker Compose files. |
 | `DCC_DASHBOARD_PORT` | `8080` | HTTP port for serving the control center dashboard. |
+| `DCC_API_PORT` | `4000` | HTTP port for the Express backend API. |
+| `DCC_API_CORS_ORIGIN` | `*` | Allowed origin(s) for API CORS requests. |
+| `DCC_API_AUTOSTART_TELEMETRY` | `false` | Set to `true` to launch periodic Docker telemetry polling on boot. |
 | `DCC_REFRESH_INTERVAL` | `auto` | Frontend polling/streaming strategy; must avoid full page refresh loops. |
 | `DCC_INSTALL_DIR` | `/opt/dcc` | Target directory used by the setup automation for deploying build artifacts. |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,142 @@
+# Backend API Reference
+
+The Docker Control Center (DCC) backend API exposes lifecycle automation, telemetry, and marketplace
+management over HTTP. The service is a lightweight Express server that wraps the
+`AppLifecycleManager` and `DockerOrchestrator` classes.
+
+- **Base URL:** `http://localhost:${DCC_API_PORT:-4000}`
+- **Authentication:** Not yet implemented (deploy behind your network perimeter).
+- **Content Type:** `application/json`
+
+## Quick Start
+
+```bash
+# Start the API (requires DATABASE_URL and Prisma migrations)
+npm run api:start
+
+# Register a new application
+curl -X POST http://localhost:4000/apps \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "Stable Diffusion",
+        "repositoryUrl": "https://github.com/example/stable-diffusion.git",
+        "port": 7860,
+        "startCommand": "python launch.py --listen",
+        "install": true,
+        "skipClone": true
+      }'
+```
+
+## Responses and Errors
+
+Successful requests return a `data` payload. Failures return an `error` object with
+an RFC-7807 style structure:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Application name already exists.",
+    "details": { "field": "name" }
+  }
+}
+```
+
+| Error Code | HTTP Status | Description |
+| --- | --- | --- |
+| `validation_error` | 400 / 404 | Invalid request payload or missing records. |
+| `installation_error` | 409 | Docker/installation failure. |
+| `internal_error` | 500 | Unexpected server error. |
+
+## Endpoints
+
+### Health
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/healthz` | Returns `{ "status": "ok" }` for readiness/liveness probes. |
+
+### Applications
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/apps` | List apps with container state, settings, and derived `openAppUrl`. |
+| `GET` | `/apps/:id` | Fetch a single app by ID. |
+| `POST` | `/apps` | Register a new app. Include `install: true` to immediately install. |
+| `POST` | `/apps/:id/install` | Install or reinstall the workspace (`skipClone` optional). |
+| `POST` | `/apps/:id/start` | Start the Compose stack. |
+| `POST` | `/apps/:id/stop` | Stop the stack (`removeVolumes` optional, default `false`). |
+| `POST` | `/apps/:id/restart` | Restart the stack in place. |
+| `POST` | `/apps/:id/reinstall` | Stop, recreate, and start the stack (`skipClone` optional). |
+| `DELETE` | `/apps/:id` | Tear down containers and clean the workspace (`removeVolumes` optional, default `true`). |
+| `PATCH` | `/apps/:id/settings` | Update persisted settings such as `openAppBaseUrl`. |
+
+**Request Body – `POST /apps`**
+
+```json
+{
+  "name": "Stable Diffusion",
+  "repositoryUrl": "https://github.com/example/sd.git",
+  "startCommand": "python launch.py --listen",
+  "port": 7860,
+  "healthEndpoint": "/healthz",
+  "notes": "GPU heavy",
+  "install": true,
+  "skipClone": false
+}
+```
+
+**Response – `GET /apps/:id`**
+
+```json
+{
+  "data": {
+    "id": "app_123",
+    "name": "Stable Diffusion",
+    "workspaceSlug": "stable-diffusion",
+    "status": "RUNNING",
+    "port": 7860,
+    "openAppBaseUrl": "http://edge-gateway",
+    "openAppUrl": "http://edge-gateway:7860",
+    "containerStates": [
+      {
+        "containerName": "dcc-stable-diffusion",
+        "status": "RUNNING",
+        "metrics": { "cpuPercent": 12.4 },
+        "state": { "Status": "running" }
+      }
+    ]
+  }
+}
+```
+
+### Marketplace Templates
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/templates` | List marketplace templates. |
+| `GET` | `/templates/:id` | Fetch a single template. |
+| `POST` | `/templates` | Create a template (`name` required). |
+| `PATCH` | `/templates/:id` | Update a template. |
+| `DELETE` | `/templates/:id` | Delete a template. |
+
+### Telemetry
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/telemetry/collect` | Trigger a one-off Docker telemetry sweep. |
+
+The server can also auto-start periodic polling when `DCC_API_AUTOSTART_TELEMETRY=true`.
+
+## Derived Fields
+
+- `openAppUrl` combines `openAppBaseUrl` (from `App` or `AppSettings`) with the app port.
+- `containerStates[].metrics` and `containerStates[].state` are parsed JSON objects even
+  though they are stored as strings in SQLite.
+
+## Operational Notes
+
+- The API reuses the Prisma client; ensure `DATABASE_URL` points to a migrated schema.
+- All lifecycle endpoints ultimately shell out to Docker; run the API with the necessary
+  permissions (e.g., rootless Docker group membership).
+- Wrap the service in an authenticating proxy before exposing it to untrusted networks.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -45,7 +45,7 @@
 | Component | Responsibility |
 | --- | --- |
 | Web Frontend | Responsive UI for onboarding dialogs, marketplace browsing, status table, and lifecycle actions. Employs real-time updates without constant refreshes. |
-| API / Backend | Validates submissions, manages Git interactions, renders Compose templates, orchestrates lifecycle actions, and surfaces health probes. |
+| API / Backend | Express service in `src/server/` that validates submissions, manages Git interactions, renders Compose templates, orchestrates lifecycle actions, and surfaces health probes via documented REST endpoints. |
 | Lifecycle Manager | Node.js service (`AppLifecycleManager`) that validates inputs, derives workspace slugs, syncs Git repositories, writes Compose manifests, executes `docker compose up -d`, and now provides start/stop/restart/reinstall/deinstall helpers that wrap Docker CLI commands while updating Prisma status fields. |
 | Telemetry Orchestrator | Background service (`DockerOrchestrator`) that polls Docker, stores normalized telemetry in `DockerContainerState`, and hydrates dashboard-ready payloads including "Open App" URLs from `AppSettings`. |
 | Worker / Runner | Executes repository cloning, dependency installation, compose orchestration, and port health checks with GPU support. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,9 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
 | `DCC_INSTALL_DIR` | Target directory for setup automation deployments (`/opt/dcc` by default). | Override when `/opt` is restricted or to stage multiple environments. |
 | `DCC_BASE_IMAGE` | NVIDIA-enabled Docker image tag for generated services. | Use images compatible with the NVIDIA Container Toolkit and target CUDA version. |
 | `DCC_DASHBOARD_PORT` | Exposed HTTP port for the operator dashboard. | Configure reverse proxy if public access is required. |
+| `DCC_API_PORT` | HTTP port for the Express API (`4000` default). | Ensure the port is reachable from the dashboard/frontend. |
+| `DCC_API_CORS_ORIGIN` | Allowed CORS origin(s) for the API. | Use a comma-separated list or `*` for development. |
+| `DCC_API_AUTOSTART_TELEMETRY` | Enables background Docker telemetry polling when `true`. | Defaults to `false`; requires Docker access. |
 | `DCC_REFRESH_INTERVAL` | Controls UI update cadence (e.g., websocket, SSE, polling). | Favor streaming mechanisms to avoid full page reloads. |
 | `DCC_ALLOWED_REPOS` | Optional allowlist of Git hosts or orgs. | Enforce compliance and security policies. |
 | `DCC_LOG_LEVEL` | Logging verbosity (`info`, `debug`, etc.). | Increase temporarily for troubleshooting. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,39 @@
       "name": "docker-control-center",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^5.16.1"
+        "@prisma/client": "^5.16.1",
+        "cors": "^2.8.5",
+        "express": "^4.19.2"
       },
       "devDependencies": {
-        "prisma": "^5.16.1"
+        "prisma": "^5.16.1",
+        "supertest": "^6.3.4"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@prisma/client": {
@@ -85,6 +111,441 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -99,6 +560,289 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/prisma": {
       "version": "5.22.0",
@@ -119,6 +863,370 @@
       "optionalDependencies": {
         "fsevents": "2.3.3"
       }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "node scripts/build.js",
     "start": "node scripts/serve.js --root dist",
     "test": "node --test",
+    "api:start": "node src/server/index.js",
     "db:generate": "prisma generate",
     "db:deploy": "prisma migrate deploy",
     "db:seed": "prisma db seed"
@@ -16,10 +17,13 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@prisma/client": "^5.16.1"
+    "@prisma/client": "^5.16.1",
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
   },
   "devDependencies": {
-    "prisma": "^5.16.1"
+    "prisma": "^5.16.1",
+    "supertest": "^6.3.4"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import cors from 'cors';
+import { createAppsRouter } from './routes/apps.js';
+import { createTemplatesRouter } from './routes/templates.js';
+import { createTelemetryRouter } from './routes/telemetry.js';
+import { createErrorHandler, createNotFoundHandler } from './errorHandler.js';
+import { createAppLifecycleManager } from '../framework/appLifecycleManager.js';
+import { createDockerOrchestrator } from '../framework/dockerOrchestrator.js';
+
+export function createApiServer({
+  prisma,
+  logger = console,
+  lifecycleManager,
+  orchestrator,
+  corsOrigin = '*'
+} = {}) {
+  if (!prisma) {
+    throw new Error('Prisma client instance is required.');
+  }
+
+  const app = express();
+  const lifecycle =
+    lifecycleManager ??
+    createAppLifecycleManager({
+      prisma,
+      logger
+    });
+  const dockerOrchestrator =
+    orchestrator ??
+    createDockerOrchestrator({
+      prisma,
+      logger
+    });
+
+  app.disable('x-powered-by');
+  app.use(cors({ origin: corsOrigin }));
+  app.use(express.json({ limit: '2mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  app.get('/healthz', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use(
+    '/apps',
+    createAppsRouter({ prisma, lifecycleManager: lifecycle, orchestrator: dockerOrchestrator })
+  );
+  app.use('/templates', createTemplatesRouter({ prisma }));
+  app.use('/telemetry', createTelemetryRouter({ orchestrator: dockerOrchestrator }));
+
+  app.use(createNotFoundHandler());
+  app.use(createErrorHandler(logger));
+
+  return { app, lifecycleManager: lifecycle, orchestrator: dockerOrchestrator };
+}

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,13 @@
+const DEFAULT_PORT = 4000;
+
+export function loadConfig(env = process.env) {
+  const port = Number.parseInt(env.DCC_API_PORT ?? `${DEFAULT_PORT}`, 10);
+  return {
+    port: Number.isNaN(port) ? DEFAULT_PORT : port,
+    corsOrigin: env.DCC_API_CORS_ORIGIN ?? '*',
+    logLevel: env.DCC_LOG_LEVEL ?? 'info',
+    autoStartTelemetry: env.DCC_API_AUTOSTART_TELEMETRY
+      ? env.DCC_API_AUTOSTART_TELEMETRY.toLowerCase() !== 'false'
+      : false
+  };
+}

--- a/src/server/errorHandler.js
+++ b/src/server/errorHandler.js
@@ -1,0 +1,29 @@
+import { mapErrorToHttp } from './utils.js';
+
+export function createNotFoundHandler() {
+  return (req, res) => {
+    res.status(404).json({
+      error: {
+        code: 'not_found',
+        message: 'Route not found.',
+        details: {
+          method: req.method,
+          path: req.path
+        }
+      }
+    });
+  };
+}
+
+export function createErrorHandler(logger = console) {
+  return (error, req, res, next) => {
+    if (res.headersSent) {
+      next(error);
+      return;
+    }
+
+    logger?.error?.('API request failed', error);
+    const { status, body } = mapErrorToHttp(error);
+    res.status(status).json(body);
+  };
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,52 @@
+import { PrismaClient } from '@prisma/client';
+import { loadConfig } from './config.js';
+import { createApiServer } from './app.js';
+
+async function main() {
+  const config = loadConfig();
+  const prisma = new PrismaClient();
+  await prisma.$connect();
+
+  const { app, orchestrator } = createApiServer({
+    prisma,
+    corsOrigin: config.corsOrigin
+  });
+
+  if (config.autoStartTelemetry) {
+    orchestrator
+      .start()
+      .catch((error) => console.error('Failed to start telemetry polling:', error));
+  }
+
+  const server = app.listen(config.port, '0.0.0.0', () => {
+    console.log(`DCC API listening on http://0.0.0.0:${config.port}`);
+  });
+
+  async function shutdown(signal) {
+    console.log(`Received ${signal}. Shutting down DCC API...`);
+
+    try {
+      orchestrator.stop();
+    } catch (error) {
+      console.error('Failed to stop orchestrator:', error);
+    }
+
+    await new Promise((resolve) => server.close(resolve));
+
+    try {
+      await prisma.$disconnect();
+    } catch (error) {
+      console.error('Failed to disconnect Prisma client:', error);
+    }
+
+    process.exit(0);
+  }
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+main().catch((error) => {
+  console.error('Failed to start DCC API:', error);
+  process.exit(1);
+});

--- a/src/server/routes/apps.js
+++ b/src/server/routes/apps.js
@@ -1,0 +1,156 @@
+import { Router } from 'express';
+import { mapAppRecord, asyncHandler } from '../utils.js';
+
+function toBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  }
+
+  return Boolean(value);
+}
+
+export function createAppsRouter({ prisma, lifecycleManager, orchestrator }) {
+  const router = Router();
+
+  async function fetchApp(id) {
+    return prisma.app.findUnique({
+      where: { id },
+      include: {
+        containerStates: true,
+        settings: true
+      }
+    });
+  }
+
+  router.get(
+    '/',
+    asyncHandler(async (req, res) => {
+      const apps = await prisma.app.findMany({
+        include: {
+          containerStates: true,
+          settings: true
+        }
+      });
+
+      res.json({ data: apps.map((app) => mapAppRecord(app, orchestrator)) });
+    })
+  );
+
+  router.get(
+    '/:id',
+    asyncHandler(async (req, res) => {
+      const app = await fetchApp(req.params.id);
+
+      if (!app) {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'Application not found.',
+            details: { id: req.params.id }
+          }
+        });
+        return;
+      }
+
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/',
+    asyncHandler(async (req, res) => {
+      const { install, skipClone, ...payload } = req.body ?? {};
+
+      const record = await lifecycleManager.registerApp(payload);
+
+      if (install) {
+        await lifecycleManager.installApp(record.id, {
+          skipClone: toBoolean(skipClone)
+        });
+      }
+
+      const app = await fetchApp(record.id);
+      res.status(201).json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/:id/install',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.installApp(req.params.id, {
+        skipClone: toBoolean(req.body?.skipClone)
+      });
+
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/:id/start',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.startApp(req.params.id);
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/:id/stop',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.stopApp(req.params.id, {
+        removeVolumes: toBoolean(req.body?.removeVolumes)
+      });
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/:id/restart',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.restartApp(req.params.id);
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.post(
+    '/:id/reinstall',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.reinstallApp(req.params.id, {
+        skipClone: toBoolean(req.body?.skipClone)
+      });
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.delete(
+    '/:id',
+    asyncHandler(async (req, res) => {
+      await lifecycleManager.deinstallApp(req.params.id, {
+        removeVolumes: req.body?.removeVolumes === undefined
+          ? true
+          : toBoolean(req.body.removeVolumes)
+      });
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  router.patch(
+    '/:id/settings',
+    asyncHandler(async (req, res) => {
+      await orchestrator.updateOpenAppBaseUrl(req.params.id, req.body?.openAppBaseUrl ?? null);
+      const app = await fetchApp(req.params.id);
+      res.json({ data: mapAppRecord(app, orchestrator) });
+    })
+  );
+
+  return router;
+}

--- a/src/server/routes/telemetry.js
+++ b/src/server/routes/telemetry.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { asyncHandler } from '../utils.js';
+
+export function createTelemetryRouter({ orchestrator }) {
+  const router = Router();
+
+  router.post(
+    '/collect',
+    asyncHandler(async (req, res) => {
+      const results = await orchestrator.collectTelemetry();
+      res.json({ data: results });
+    })
+  );
+
+  return router;
+}

--- a/src/server/routes/templates.js
+++ b/src/server/routes/templates.js
@@ -1,0 +1,96 @@
+import { Router } from 'express';
+import { asyncHandler } from '../utils.js';
+
+export function createTemplatesRouter({ prisma }) {
+  const router = Router();
+
+  router.get(
+    '/',
+    asyncHandler(async (req, res) => {
+      const templates = await prisma.marketplaceTemplate.findMany();
+      res.json({ data: templates });
+    })
+  );
+
+  router.get(
+    '/:id',
+    asyncHandler(async (req, res) => {
+      const template = await prisma.marketplaceTemplate.findUnique({
+        where: { id: req.params.id }
+      });
+
+      if (!template) {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'Marketplace template not found.',
+            details: { id: req.params.id }
+          }
+        });
+        return;
+      }
+
+      res.json({ data: template });
+    })
+  );
+
+  router.post(
+    '/',
+    asyncHandler(async (req, res) => {
+      const payload = req.body ?? {};
+      const template = await prisma.marketplaceTemplate.create({ data: payload });
+      res.status(201).json({ data: template });
+    })
+  );
+
+  router.patch(
+    '/:id',
+    asyncHandler(async (req, res) => {
+      const existing = await prisma.marketplaceTemplate.findUnique({
+        where: { id: req.params.id }
+      });
+
+      if (!existing) {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'Marketplace template not found.',
+            details: { id: req.params.id }
+          }
+        });
+        return;
+      }
+
+      const template = await prisma.marketplaceTemplate.update({
+        where: { id: req.params.id },
+        data: req.body ?? {}
+      });
+      res.json({ data: template });
+    })
+  );
+
+  router.delete(
+    '/:id',
+    asyncHandler(async (req, res) => {
+      const existing = await prisma.marketplaceTemplate.findUnique({
+        where: { id: req.params.id }
+      });
+
+      if (!existing) {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'Marketplace template not found.',
+            details: { id: req.params.id }
+          }
+        });
+        return;
+      }
+
+      await prisma.marketplaceTemplate.delete({ where: { id: req.params.id } });
+      res.status(204).end();
+    })
+  );
+
+  return router;
+}

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -1,0 +1,93 @@
+import { AppValidationError, InstallationError } from '../framework/errors.js';
+
+export function asyncHandler(handler) {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}
+
+export function parseJson(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function mapContainerState(state) {
+  if (!state) {
+    return null;
+  }
+
+  return {
+    ...state,
+    metrics: parseJson(state.metrics ?? null),
+    state: parseJson(state.state ?? null)
+  };
+}
+
+export function mapAppRecord(app, orchestrator) {
+  if (!app) {
+    return null;
+  }
+
+  const containerStates = Array.isArray(app.containerStates)
+    ? app.containerStates.map((entry) => mapContainerState(entry))
+    : [];
+
+  const openAppUrl = orchestrator?.buildOpenAppUrl?.(app) ?? null;
+
+  return {
+    ...app,
+    containerStates,
+    openAppUrl
+  };
+}
+
+export function mapErrorToHttp(error) {
+  if (error instanceof AppValidationError) {
+    const status = error.details?.reason === 'not-found' ? 404 : 400;
+    return {
+      status,
+      body: {
+        error: {
+          code: 'validation_error',
+          message: error.message,
+          details: error.details ?? null
+        }
+      }
+    };
+  }
+
+  if (error instanceof InstallationError) {
+    return {
+      status: 409,
+      body: {
+        error: {
+          code: 'installation_error',
+          message: error.message,
+          details: error.details ?? null
+        }
+      }
+    };
+  }
+
+  return {
+    status: 500,
+    body: {
+      error: {
+        code: 'internal_error',
+        message: 'Unexpected server error.',
+        details: null
+      }
+    }
+  };
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,204 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import request from 'supertest';
+import { AppLifecycleManager } from '../src/framework/appLifecycleManager.js';
+import { createApiServer } from '../src/server/app.js';
+import { createPrismaDouble } from './helpers/prismaDouble.js';
+
+class StubOrchestrator {
+  constructor(prisma) {
+    this.prisma = prisma;
+    this.collectCount = 0;
+  }
+
+  async collectTelemetry() {
+    this.collectCount += 1;
+    return [{ appId: 'demo', containerName: 'demo', status: 'RUNNING', health: 'HEALTHY', metrics: null, state: null }];
+  }
+
+  async updateOpenAppBaseUrl(appId, openAppBaseUrl) {
+    const sanitized = openAppBaseUrl?.trim() || null;
+
+    await this.prisma.app.update({
+      where: { id: appId },
+      data: { openAppBaseUrl: sanitized }
+    });
+
+    await this.prisma.appSettings.upsert({
+      where: { appId },
+      update: { openAppBaseUrl: sanitized },
+      create: { appId, openAppBaseUrl: sanitized }
+    });
+
+    return this.prisma.app.findUnique({
+      where: { id: appId },
+      select: { id: true, port: true, openAppBaseUrl: true }
+    });
+  }
+
+  buildOpenAppUrl(app) {
+    if (!app) {
+      return null;
+    }
+
+    const base = app.openAppBaseUrl ?? app.settings?.openAppBaseUrl ?? null;
+
+    if (!base) {
+      return null;
+    }
+
+    if (!app.port) {
+      return base;
+    }
+
+    const sanitized = base.endsWith('/') ? base.slice(0, -1) : base;
+    return `${sanitized}:${app.port}`;
+  }
+
+  stop() {}
+}
+
+const silentLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
+};
+
+async function createServerContext({ apps = [], templates = [] } = {}) {
+  const prisma = createPrismaDouble({ apps, templates });
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dcc-api-'));
+  const commands = [];
+
+  const lifecycleManager = new AppLifecycleManager({
+    prisma,
+    workspaceRoot,
+    fileSystem: fs,
+    commandRunner: async (cmd, args) => {
+      commands.push({ cmd, args });
+      return { stdout: '', stderr: '' };
+    },
+    logger: silentLogger
+  });
+
+  const orchestrator = new StubOrchestrator(prisma);
+  const { app } = createApiServer({
+    prisma,
+    lifecycleManager,
+    orchestrator,
+    logger: silentLogger,
+    corsOrigin: '*'
+  });
+
+  return {
+    app,
+    prisma,
+    commands,
+    orchestrator,
+    lifecycleManager,
+    async cleanup() {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  };
+}
+
+test('GET /healthz returns ok status payload', async (t) => {
+  const ctx = await createServerContext();
+  t.after(() => ctx.cleanup());
+
+  const response = await request(ctx.app).get('/healthz');
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, { status: 'ok' });
+});
+
+test('POST /apps registers a new application record', async (t) => {
+  const ctx = await createServerContext();
+  t.after(() => ctx.cleanup());
+
+  const payload = {
+    name: 'Stable Diffusion',
+    repositoryUrl: 'https://example.com/sd.git',
+    port: 7860,
+    startCommand: 'python launch.py --listen'
+  };
+
+  const response = await request(ctx.app).post('/apps').send(payload);
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.data.name, 'Stable Diffusion');
+  assert.equal(response.body.data.port, 7860);
+  assert.match(response.body.data.workspaceSlug, /^stable-diffusion/);
+
+  const created = ctx.prisma.state.apps.find((app) => app.name === 'Stable Diffusion');
+  assert.ok(created, 'app should be stored');
+});
+
+test('POST /apps/:id/install provisions the workspace and updates status', async (t) => {
+  const ctx = await createServerContext();
+  t.after(() => ctx.cleanup());
+
+  const created = await request(ctx.app)
+    .post('/apps')
+    .send({ name: 'Installable App', repositoryUrl: null, port: 9000, startCommand: 'npm start' });
+
+  const installResponse = await request(ctx.app)
+    .post(`/apps/${created.body.data.id}/install`)
+    .send({ skipClone: true });
+
+  assert.equal(installResponse.status, 200);
+  assert.equal(installResponse.body.data.status, 'RUNNING');
+  assert.equal(ctx.commands.length, 1);
+  assert.equal(ctx.commands[0].cmd, 'docker');
+  assert.equal(ctx.commands[0].args[0], 'compose');
+  assert.deepEqual(ctx.commands[0].args.slice(-2), ['up', '-d']);
+});
+
+test('PATCH /apps/:id/settings stores the Open App base URL and returns derived link', async (t) => {
+  const ctx = await createServerContext({
+    apps: [
+      {
+        id: 'app-1',
+        name: 'Settings Demo',
+        workspaceSlug: 'settings-demo',
+        port: 7000,
+        status: 'STOPPED'
+      }
+    ]
+  });
+  t.after(() => ctx.cleanup());
+
+  const response = await request(ctx.app)
+    .patch('/apps/app-1/settings')
+    .send({ openAppBaseUrl: 'http://edge-gateway/' });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.data.openAppBaseUrl, 'http://edge-gateway/');
+  assert.equal(response.body.data.openAppUrl, 'http://edge-gateway:7000');
+});
+
+test('POST /telemetry/collect invokes orchestrator and returns results', async (t) => {
+  const ctx = await createServerContext();
+  t.after(() => ctx.cleanup());
+
+  const response = await request(ctx.app).post('/telemetry/collect');
+  assert.equal(response.status, 200);
+  assert.equal(ctx.orchestrator.collectCount, 1);
+  assert.equal(Array.isArray(response.body.data), true);
+});
+
+test('GET /templates returns marketplace templates', async (t) => {
+  const ctx = await createServerContext({
+    templates: [
+      { id: 'tpl-1', name: 'Stable Diffusion', summary: 'GPU image' },
+      { id: 'tpl-2', name: 'Dreambooth', summary: 'Training pipeline' }
+    ]
+  });
+  t.after(() => ctx.cleanup());
+
+  const response = await request(ctx.app).get('/templates');
+  assert.equal(response.status, 200);
+  assert.equal(response.body.data.length, 2);
+});

--- a/tests/helpers/prismaDouble.js
+++ b/tests/helpers/prismaDouble.js
@@ -103,6 +103,49 @@ export function createPrismaDouble({ apps = [], templates = [], containerStates 
       }
 
       return null;
+    },
+
+    async findMany() {
+      return state.templates.map((template) => ({ ...template }));
+    },
+
+    async create({ data }) {
+      const record = {
+        id: data.id ?? `tpl_${state.templates.length + 1}`,
+        createdAt: data.createdAt ?? new Date(),
+        updatedAt: data.updatedAt ?? new Date(),
+        ...data
+      };
+      state.templates.push(record);
+      return { ...record };
+    },
+
+    async update({ where, data }) {
+      const index = state.templates.findIndex((template) => template.id === where.id);
+
+      if (index === -1) {
+        throw new Error(`Template with id ${where.id} not found.`);
+      }
+
+      const updated = {
+        ...state.templates[index],
+        ...data,
+        updatedAt: data.updatedAt ?? new Date()
+      };
+
+      state.templates[index] = updated;
+      return { ...updated };
+    },
+
+    async delete({ where }) {
+      const index = state.templates.findIndex((template) => template.id === where.id);
+
+      if (index === -1) {
+        throw new Error(`Template with id ${where.id} not found.`);
+      }
+
+      const [removed] = state.templates.splice(index, 1);
+      return { ...removed };
     }
   };
 


### PR DESCRIPTION
## Why
- provide the dashboard with a real backend surface for lifecycle operations and telemetry

## What
- add an Express-based API server with lifecycle, telemetry, and marketplace routes plus shared error handling utilities
- expose configuration helpers, startup script, and Prisma doubles/test coverage for the API workflow
- document the HTTP contract, configuration variables, and README quick-start updates for running the backend

## Impact
- new `npm run api:start` process listens on `DCC_API_PORT`; requires Prisma connectivity and Docker access when invoking lifecycle endpoints

## Testing
- `npm test`

## Docs
- README.md, docs/api.md, docs/configuration.md, docs/architecture-overview.md

### Changelog
```
## [2025-10-06 13:00] Launch Express backend API
**Change Type:** Normal Change  
**Why:** Provide a real backend for the dashboard to register, install, and monitor applications.  
**What changed:** Added an Express-based API server with lifecycle, telemetry, and marketplace routes; introduced configuration helpers, error handling, and REST documentation; updated tests with Supertest coverage.  
**Impact:** New `npm run api:start` process exposes management endpoints on `DCC_API_PORT`; ensure Docker/Prisma connectivity before enabling auto-telemetry.  
**Testing:** `npm test`  
**Docs:** README.md, docs/api.md, docs/architecture-overview.md, docs/configuration.md updated.  
**Rollback Plan:** Revert the API server commit and remove the new documentation/tests.  
**Refs:** N/A
```


------
https://chatgpt.com/codex/tasks/task_e_68e13cac279c8333910101df21d11d03