### PR TITLE
api: default DATABASE_URL fallback to bundled sqlite

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -139,11 +139,21 @@
 **Refs:** N/A
 
 ## [2025-10-06 18:00] Connect dashboard marketplace to backend deployments
-**Change Type:** Normal Change  
-**Why:** Ensure new applications created via the UI install through Docker with the NVIDIA base image and Git checkout.  
-**What changed:** Wired the dashboard to the Express API for template CRUD and app lifecycle actions, added Docker image pulls to `installApp`, persisted marketplace start commands, refreshed build assets, and updated docs to describe the backend-powered flow.  
-**Impact:** Deploy, start, stop, and reinstall actions now execute against Docker; the UI no longer relies on local storage. Operators must run the API with Docker access so image pulls and git clones succeed.  
-**Testing:** `npm run build`, `npm test`  
-**Docs:** README.md, docs/api.md, docs/architecture-overview.md updated.  
-**Rollback Plan:** Revert this change set and rerun `npm run build` to regenerate the previous static assets.  
+**Change Type:** Normal Change
+**Why:** Ensure new applications created via the UI install through Docker with the NVIDIA base image and Git checkout.
+**What changed:** Wired the dashboard to the Express API for template CRUD and app lifecycle actions, added Docker image pulls to `installApp`, persisted marketplace start commands, refreshed build assets, and updated docs to describe the backend-powered flow.
+**Impact:** Deploy, start, stop, and reinstall actions now execute against Docker; the UI no longer relies on local storage. Operators must run the API with Docker access so image pulls and git clones succeed.
+**Testing:** `npm run build`, `npm test`
+**Docs:** README.md, docs/api.md, docs/architecture-overview.md updated.
+**Rollback Plan:** Revert this change set and rerun `npm run build` to regenerate the previous static assets.
+**Refs:** N/A
+
+## [2025-10-07 09:00] Restore API database connectivity defaults
+**Change Type:** Emergency Change
+**Why:** Dashboard API calls were failing when `DATABASE_URL` was missing, blocking template saves and telemetry loads.
+**What changed:** Added a runtime fallback that injects the bundled SQLite database URL, warns operators when auto-selected, and covered the behavior with unit tests alongside doc updates.
+**Impact:** API boots successfully without explicit database configuration while remaining overrideable; existing deployments remain compatible.
+**Testing:** `npm test`
+**Docs:** README.md, docs/configuration.md updated.
+**Rollback Plan:** Revert the fallback commit and remove the new tests/documentation.
 **Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ await orchestrator.updateOpenAppBaseUrl(app.id, 'http://edge-gateway');
 - Prisma schema lives in `prisma/schema.prisma` and targets SQLite by default.
 - Docker telemetry snapshots (`state`, `metrics`) are stored as JSON-encoded text to keep SQLite compatibility; parse before using them downstream.
 - Seed routine (`prisma/seed.js`) now removes legacy demo entries so you always start from a clean slate before onboarding your own apps.
-- Override the `DATABASE_URL` environment variable to point at production-grade storage. The setup automation falls back to `file:/opt/dcc/data/dcc.sqlite` when none is provided.
+- Override the `DATABASE_URL` environment variable to point at production-grade storage. When unset, the API now falls back to the bundled SQLite database at `prisma/dev.db` (full path resolved automatically) while the setup automation still targets `file:/opt/dcc/data/dcc.sqlite` for host installs.
 
 Detailed lifecycle and automation guidance lives in [`docs/architecture-overview.md`](docs/architecture-overview.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ The Docker Control Center (DCC) relies on environment variables to orchestrate G
 | `DCC_REFRESH_INTERVAL` | Controls UI update cadence (e.g., websocket, SSE, polling). | Favor streaming mechanisms to avoid full page reloads. |
 | `DCC_ALLOWED_REPOS` | Optional allowlist of Git hosts or orgs. | Enforce compliance and security policies. |
 | `DCC_LOG_LEVEL` | Logging verbosity (`info`, `debug`, etc.). | Increase temporarily for troubleshooting. |
-| `DATABASE_URL` | Prisma connection string. Defaults to SQLite under `/opt/dcc/data/dcc.sqlite`. | Point at PostgreSQL/MySQL for production or keep SQLite for embedded deployments. |
+| `DATABASE_URL` | Prisma connection string. Defaults to SQLite under `/opt/dcc/data/dcc.sqlite` (installer) or the in-repo fallback `prisma/dev.db` when the API boots without an override. | Point at PostgreSQL/MySQL for production or keep SQLite for embedded deployments. |
 
 ## Database-backed Settings
 - Operator-facing preferences such as custom "Open App" hosts are persisted via Prisma (`AppSettings.openAppBaseUrl`).

--- a/src/server/database.js
+++ b/src/server/database.js
@@ -1,0 +1,31 @@
+import { env as processEnv } from 'node:process';
+
+const FALLBACK_DATABASE_URL = new URL('../../prisma/dev.db', import.meta.url).toString();
+
+function isEmpty(value) {
+  return value === undefined || value === null || String(value).trim() === '';
+}
+
+export function resolveDatabaseUrl({ env = processEnv } = {}) {
+  if (!isEmpty(env.DATABASE_URL)) {
+    return env.DATABASE_URL;
+  }
+
+  return FALLBACK_DATABASE_URL;
+}
+
+export function ensureDatabaseUrl({ env = processEnv, logger = console } = {}) {
+  const url = resolveDatabaseUrl({ env });
+
+  if (isEmpty(env.DATABASE_URL)) {
+    env.DATABASE_URL = url;
+
+    logger?.warn?.(
+      `DATABASE_URL was not provided. Falling back to embedded SQLite database at ${url}.`
+    );
+  }
+
+  return url;
+}
+
+export { FALLBACK_DATABASE_URL };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,9 +1,11 @@
 import { PrismaClient } from '@prisma/client';
 import { loadConfig } from './config.js';
 import { createApiServer } from './app.js';
+import { ensureDatabaseUrl } from './database.js';
 
 async function main() {
   const config = loadConfig();
+  ensureDatabaseUrl({ logger: console });
   const prisma = new PrismaClient();
   await prisma.$connect();
 

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ensureDatabaseUrl,
+  resolveDatabaseUrl,
+  FALLBACK_DATABASE_URL
+} from '../src/server/database.js';
+
+test('resolveDatabaseUrl returns provided DATABASE_URL env value', () => {
+  const env = { DATABASE_URL: 'postgresql://example' };
+  const url = resolveDatabaseUrl({ env });
+
+  assert.equal(url, 'postgresql://example');
+});
+
+test('resolveDatabaseUrl falls back to bundled SQLite path when unset', () => {
+  const env = {};
+  const url = resolveDatabaseUrl({ env });
+
+  assert.equal(url, FALLBACK_DATABASE_URL);
+});
+
+test('ensureDatabaseUrl injects fallback value and logs a warning when missing', () => {
+  const env = {};
+  const warnings = [];
+  const logger = { warn: (message) => warnings.push(message) };
+
+  const url = ensureDatabaseUrl({ env, logger });
+
+  assert.equal(url, FALLBACK_DATABASE_URL);
+  assert.equal(env.DATABASE_URL, FALLBACK_DATABASE_URL);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Falling back to embedded SQLite database/);
+});
+
+test('ensureDatabaseUrl preserves preconfigured DATABASE_URL and avoids warnings', () => {
+  const env = { DATABASE_URL: 'file:./custom.db' };
+  const warnings = [];
+  const logger = { warn: (message) => warnings.push(message) };
+
+  const url = ensureDatabaseUrl({ env, logger });
+
+  assert.equal(url, 'file:./custom.db');
+  assert.equal(env.DATABASE_URL, 'file:./custom.db');
+  assert.equal(warnings.length, 0);
+});


### PR DESCRIPTION
## Why
- restore dashboard API functionality when operators forget to set `DATABASE_URL`

## What
- add a runtime helper that injects the bundled SQLite URL whenever `DATABASE_URL` is empty
- warn about the fallback, cover the behavior with node:test cases, and document the new default

## Impact
- API boots successfully in fresh environments while remaining overrideable for managed databases

## Testing
- `npm test`

## Docs
- README.md
- docs/configuration.md

## Changelog
```
## [2025-10-07 09:00] Restore API database connectivity defaults
**Change Type:** Emergency Change
**Why:** Dashboard API calls were failing when `DATABASE_URL` was missing, blocking template saves and telemetry loads.
**What changed:** Added a runtime fallback that injects the bundled SQLite database URL, warns operators when auto-selected, and covered the behavior with unit tests alongside doc updates.
**Impact:** API boots successfully without explicit database configuration while remaining overrideable; existing deployments remain compatible.
**Testing:** `npm test`
**Docs:** README.md, docs/configuration.md updated.
**Rollback Plan:** Revert the fallback commit and remove the new tests/documentation.
**Refs:** N/A
```

------
https://chatgpt.com/codex/tasks/task_e_68e14e22ed108333b4855bc149e099fa